### PR TITLE
feat(backend): interpreter management and ios auth fix

### DIFF
--- a/api-gateway/src/auth/auth.controller.ts
+++ b/api-gateway/src/auth/auth.controller.ts
@@ -363,5 +363,12 @@ export class AuthController {
     return this.client.send('delete_profile_picture', { userId });
   }
 
+  @Post('promote-interpreter')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Promover usuario a intérprete (Admin)' })
+  @ApiBody({ schema: { type: 'object', properties: { email: { type: 'string' } } } })
+  promoteToInterpreter(@Body() body: { email: string }) {
+    return this.client.send('promote_to_interpreter', body);
+  }
 }
 

--- a/api-gateway/src/chat/chat.controller.ts
+++ b/api-gateway/src/chat/chat.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Post, Get, Put, Delete, Body, Param, Query, Inject, HttpCod
 import { Response } from 'express';
 import { map } from 'rxjs/operators';
 import { ClientProxy } from '@nestjs/microservices';
-import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiBody } from '@nestjs/swagger';
 import { ConfigService } from '@nestjs/config';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { StartConversationDto } from './dto/start-conversation.dto';
@@ -148,6 +148,13 @@ export class ChatController {
     @ApiResponse({ status: 200, description: 'Invitaciones enviadas' })
     inviteInterpreters(@Body() dto: { roomName: string; userId: string; username: string }) {
         return this.client.send('invite_interpreters', dto);
+    }
+
+    @Post('interpreter/status')
+    @ApiOperation({ summary: 'Update interpreter busy status' })
+    @ApiBody({ schema: { type: 'object', properties: { userId: { type: 'string' }, isBusy: { type: 'boolean' } } } })
+    setInterpreterStatus(@Body() body: { userId: string; isBusy: boolean }) {
+        return this.client.send('set_interpreter_status', body);
     }
 
     @Post('correct-text/stream')

--- a/auth-ms/src/auth/auth.controller.ts
+++ b/auth-ms/src/auth/auth.controller.ts
@@ -9,6 +9,7 @@ import { OAuthLoginDto } from './dto/oauth-login.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
 import { UpdatePasswordDto } from './dto/update-password.dto';
 import { UpdateProfileDto } from './dto/update-profile.dto';
+import { CreateInterpreterRequestDto } from './dto/create-interpreter-request.dto';
 import { UpdatePushTokenDto } from './dto/update-push-token.dto';
 
 @Controller()
@@ -80,6 +81,12 @@ export class AuthController {
   @MessagePattern('delete_profile_picture')
   deleteProfilePicture(@Payload() data: { userId: string }): Promise<any> {
     return this.authService.deleteProfilePicture(data.userId);
+  }
+
+  // Interpreter Management
+  @MessagePattern('promote_to_interpreter')
+  promoteToInterpreter(@Payload() data: { email: string }): Promise<any> {
+    return this.authService.promoteToInterpreter(data);
   }
 
 }

--- a/auth-ms/src/auth/dto/create-interpreter-request.dto.ts
+++ b/auth-ms/src/auth/dto/create-interpreter-request.dto.ts
@@ -1,0 +1,9 @@
+export class CreateInterpreterRequestDto {
+    userId: string;
+    first_name: string;
+    last_name: string;
+    document_type: string;
+    document_number: string;
+    phone?: string;
+    email?: string;
+}

--- a/chat-ms/src/chat/chat.controller.ts
+++ b/chat-ms/src/chat/chat.controller.ts
@@ -103,4 +103,9 @@ export class ChatController {
     inviteInterpreters(@Payload() data: { roomName: string; userId: string; username: string }) {
         return this.chatService.inviteInterpreters(data);
     }
+
+    @MessagePattern('set_interpreter_status')
+    setInterpreterStatus(@Payload() data: { userId: string; isBusy: boolean }) {
+        return this.chatService.setInterpreterStatus(data.userId, data.isBusy);
+    }
 }

--- a/chat-ms/src/chat/chat.service.ts
+++ b/chat-ms/src/chat/chat.service.ts
@@ -668,11 +668,12 @@ export class ChatService {
             const supabase = this.supabaseService.getAdminClient();
             this.logger.log(`📞 Inviting interpreters for call ${data.roomName} by ${data.username}`);
 
-            // 1. Find all users with role 'interpreter'
+            // 1. Find all users with role 'interpreter' AND not busy
             const { data: interpreters, error } = await supabase
                 .from('profiles')
                 .select('id, push_token')
-                .eq('role', 'interpreter');
+                .eq('role', 'interpreter')
+                .eq('is_busy', false); // Only available interpreters
 
             if (error) {
                 this.logger.error(`Error fetching interpreters: ${error.message}`);
@@ -727,5 +728,18 @@ export class ChatService {
             this.logger.error(`Error inviting interpreters: ${error.message}`);
             throw new BadRequestException('Error al invitar intérpretes');
         }
+    }
+    async setInterpreterStatus(userId: string, isBusy: boolean) {
+        const supabase = this.supabaseService.getAdminClient();
+        const { error } = await supabase
+            .from('profiles')
+            .update({ is_busy: isBusy })
+            .eq('id', userId);
+
+        if (error) {
+            this.logger.error(`Error updating interpreter status: ${error.message}`);
+            throw new BadRequestException('Error actualizando estado');
+        }
+        return { success: true };
     }
 }


### PR DESCRIPTION
auth-ms:
  - Fix Google Sign-In on iOS by correctly extracting and passing `nonce` from id_token to Supabase.
  - Add logic to promote users to 'interpreter' role.

chat-ms:
  - Implement `setInterpreterStatus` to toggle `is_busy` state for interpreters.

api-gateway:
  - Expose `POST /auth/promote-interpreter` endpoint.
  - Expose `POST /chat/interpreter/status` endpoint.