### PR TITLE
feat(chat): implement group management functionalities

### DIFF
--- a/api-gateway/src/chat/chat.controller.ts
+++ b/api-gateway/src/chat/chat.controller.ts
@@ -10,6 +10,7 @@ import { CreateGroupDto } from './dto/create-group.dto';
 import { SendChatMessageDto } from './dto/send-message.dto';
 import { GetMessagesDto, GetConversationsDto, MarkAsReadDto, EditMessageDto, DeleteMessageDto } from './dto/chat.dto';
 import { AddContactDto, UpdateContactDto } from './dto/contact.dto';
+import { RemoveParticipantDto, PromoteToAdminDto, LeaveGroupDto, UpdateGroupDto } from './dto/group-management.dto';
 
 @ApiTags('Chat')
 @ApiBearerAuth()
@@ -158,6 +159,32 @@ export class ChatController {
     @ApiBody({ schema: { type: 'object', properties: { userId: { type: 'string' }, isBusy: { type: 'boolean' } } } })
     setInterpreterStatus(@Body() body: { userId: string; isBusy: boolean }) {
         return this.client.send('set_interpreter_status', body);
+    }
+
+    // ===== GESTIÓN DE GRUPOS =====
+
+    @Post('groups/remove')
+    @ApiOperation({ summary: 'Eliminar participante del grupo' })
+    removeParticipant(@Body() dto: RemoveParticipantDto) {
+        return this.client.send('remove_participant', dto);
+    }
+
+    @Post('groups/promote')
+    @ApiOperation({ summary: 'Promover a administrador del grupo' })
+    promoteToAdmin(@Body() dto: PromoteToAdminDto) {
+        return this.client.send('promote_to_admin', dto);
+    }
+
+    @Post('groups/leave')
+    @ApiOperation({ summary: 'Salir del grupo' })
+    leaveGroup(@Body() dto: LeaveGroupDto) {
+        return this.client.send('leave_group', dto);
+    }
+
+    @Put('groups')
+    @ApiOperation({ summary: 'Actualizar información del grupo' })
+    updateGroup(@Body() dto: UpdateGroupDto) {
+        return this.client.send('update_group', dto);
     }
 
     @Post('correct-text/stream')

--- a/api-gateway/src/chat/dto/group-management.dto.ts
+++ b/api-gateway/src/chat/dto/group-management.dto.ts
@@ -1,0 +1,48 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RemoveParticipantDto {
+    @ApiProperty()
+    conversationId: string;
+
+    @ApiProperty()
+    adminId: string;
+
+    @ApiProperty()
+    userIdToRemove: string;
+}
+
+export class PromoteToAdminDto {
+    @ApiProperty()
+    conversationId: string;
+
+    @ApiProperty()
+    adminId: string;
+
+    @ApiProperty()
+    userIdToPromote: string;
+}
+
+export class LeaveGroupDto {
+    @ApiProperty()
+    conversationId: string;
+
+    @ApiProperty()
+    userId: string;
+}
+
+export class UpdateGroupDto {
+    @ApiProperty()
+    conversationId: string;
+
+    @ApiProperty()
+    adminId: string;
+
+    @ApiProperty({ required: false })
+    title?: string;
+
+    @ApiProperty({ required: false })
+    imageUrl?: string;
+
+    @ApiProperty({ required: false })
+    description?: string;
+}

--- a/chat-ms/src/chat/chat.controller.ts
+++ b/chat-ms/src/chat/chat.controller.ts
@@ -11,6 +11,7 @@ import { CreateGroupDto } from './dto/create-group.dto';
 import { EditMessageDto } from './dto/edit-message.dto';
 import { DeleteMessageDto } from './dto/delete-message.dto';
 import { AddContactDto, UpdateContactDto, DeleteContactDto, GetContactsDto } from './dto/contact.dto';
+import { RemoveParticipantDto, PromoteToAdminDto, LeaveGroupDto, UpdateGroupDto } from './dto/group-management.dto';
 
 @Controller()
 export class ChatController {
@@ -107,5 +108,25 @@ export class ChatController {
     @MessagePattern('set_interpreter_status')
     setInterpreterStatus(@Payload() data: { userId: string; isBusy: boolean }) {
         return this.chatService.setInterpreterStatus(data.userId, data.isBusy);
+    }
+
+    @MessagePattern('remove_participant')
+    removeParticipant(@Payload() data: RemoveParticipantDto) {
+        return this.chatService.removeParticipant(data);
+    }
+
+    @MessagePattern('promote_to_admin')
+    promoteToAdmin(@Payload() data: PromoteToAdminDto) {
+        return this.chatService.promoteToAdmin(data);
+    }
+
+    @MessagePattern('leave_group')
+    leaveGroup(@Payload() data: LeaveGroupDto) {
+        return this.chatService.leaveGroup(data);
+    }
+
+    @MessagePattern('update_group')
+    updateGroup(@Payload() data: UpdateGroupDto) {
+        return this.chatService.updateGroup(data);
     }
 }

--- a/chat-ms/src/chat/dto/group-management.dto.ts
+++ b/chat-ms/src/chat/dto/group-management.dto.ts
@@ -1,0 +1,24 @@
+export class RemoveParticipantDto {
+    conversationId: string;
+    adminId: string;
+    userIdToRemove: string;
+}
+
+export class PromoteToAdminDto {
+    conversationId: string;
+    adminId: string;
+    userIdToPromote: string;
+}
+
+export class LeaveGroupDto {
+    conversationId: string;
+    userId: string;
+}
+
+export class UpdateGroupDto {
+    conversationId: string;
+    adminId: string;
+    title?: string;
+    imageUrl?: string;
+    description?: string;
+}


### PR DESCRIPTION
- Added group management DTOs to both chat-ms and api-gateway.
- Implemented business logic in chat-ms for:
    - Removing participants from groups.
    - Promoting members to administrators.
    - Allowing members to leave groups (including last admin validation).
    - Updating group information (title, image, description).
- Added 'verifyAdmin' helper to enforce authorization for administrative actions.
- Exposed corresponding REST endpoints in api-gateway with Swagger documentation.
- Fixed 'setInterpreterStatus' syntax error in ChatService.