### PR TITLE
feat: add endpoint to fetch group participants

### DIFF
--- a/api-gateway/src/chat/chat.controller.ts
+++ b/api-gateway/src/chat/chat.controller.ts
@@ -187,6 +187,12 @@ export class ChatController {
         return this.client.send('update_group', dto);
     }
 
+    @Get('groups/:conversationId/participants')
+    @ApiOperation({ summary: 'Obtener participantes de un grupo' })
+    getParticipants(@Param('conversationId') conversationId: string) {
+        return this.client.send('get_group_participants', { conversationId });
+    }
+
     @Post('correct-text/stream')
     @ApiOperation({ summary: 'Corregir texto usando IA con streaming (SSE)' })
     @ApiResponse({ status: 200, description: 'Stream de texto corregido' })

--- a/chat-ms/src/chat/chat.controller.ts
+++ b/chat-ms/src/chat/chat.controller.ts
@@ -129,4 +129,9 @@ export class ChatController {
     updateGroup(@Payload() data: UpdateGroupDto) {
         return this.chatService.updateGroup(data);
     }
+
+    @MessagePattern('get_group_participants')
+    getGroupParticipants(@Payload() data: { conversationId: string }) {
+        return this.chatService.getGroupParticipants(data.conversationId);
+    }
 }


### PR DESCRIPTION
- Implemented getGroupParticipants method in chat-ms to retrieve members and profiles.
- Exposed get_group_participants message pattern in the chat microservice.
- Added REST endpoint GET /chat/groups/:conversationId/participants in the API Gateway.
- This allows the frontend to fetch the participants list via the API, avoiding direct Supabase queries and RLS issues.