### PR TITLE
feat(chat): implement group participant management and fix DTO validations

### DIFF
--- a/api-gateway/src/chat/chat.controller.ts
+++ b/api-gateway/src/chat/chat.controller.ts
@@ -10,7 +10,7 @@ import { CreateGroupDto } from './dto/create-group.dto';
 import { SendChatMessageDto } from './dto/send-message.dto';
 import { GetMessagesDto, GetConversationsDto, MarkAsReadDto, EditMessageDto, DeleteMessageDto } from './dto/chat.dto';
 import { AddContactDto, UpdateContactDto } from './dto/contact.dto';
-import { RemoveParticipantDto, PromoteToAdminDto, LeaveGroupDto, UpdateGroupDto } from './dto/group-management.dto';
+import { RemoveParticipantDto, PromoteToAdminDto, LeaveGroupDto, UpdateGroupDto, AddParticipantDto } from './dto/group-management.dto';
 
 @ApiTags('Chat')
 @ApiBearerAuth()
@@ -162,6 +162,12 @@ export class ChatController {
     }
 
     // ===== GESTIÓN DE GRUPOS =====
+
+    @Post('groups/add')
+    @ApiOperation({ summary: 'Añadir participante al grupo' })
+    addParticipant(@Body() dto: AddParticipantDto) {
+        return this.client.send('add_participant', dto);
+    }
 
     @Post('groups/remove')
     @ApiOperation({ summary: 'Eliminar participante del grupo' })

--- a/api-gateway/src/chat/dto/group-management.dto.ts
+++ b/api-gateway/src/chat/dto/group-management.dto.ts
@@ -1,48 +1,82 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsOptional, IsArray, IsNotEmpty } from 'class-validator';
 
 export class RemoveParticipantDto {
     @ApiProperty()
+    @IsString()
     conversationId: string;
 
     @ApiProperty()
+    @IsString()
     adminId: string;
 
     @ApiProperty()
+    @IsString()
     userIdToRemove: string;
+}
+
+export class AddParticipantDto {
+    @ApiProperty()
+    @IsString()
+    @IsNotEmpty()
+    conversationId: string;
+
+    @ApiProperty()
+    @IsString()
+    @IsNotEmpty()
+    adminId: string;
+
+    @ApiProperty()
+    @IsString()
+    @IsNotEmpty()
+    userIdToAdd: string;
 }
 
 export class PromoteToAdminDto {
     @ApiProperty()
+    @IsString()
     conversationId: string;
 
     @ApiProperty()
+    @IsString()
     adminId: string;
 
     @ApiProperty()
+    @IsString()
     userIdToPromote: string;
 }
 
 export class LeaveGroupDto {
     @ApiProperty()
+    @IsString()
     conversationId: string;
 
     @ApiProperty()
+    @IsString()
     userId: string;
 }
 
 export class UpdateGroupDto {
     @ApiProperty()
+    @IsString()
     conversationId: string;
 
     @ApiProperty()
+    @IsString()
     adminId: string;
 
     @ApiProperty({ required: false })
+    @IsString()
+    @IsOptional()
     title?: string;
 
     @ApiProperty({ required: false })
+    @IsString()
+    @IsOptional()
     imageUrl?: string;
 
     @ApiProperty({ required: false })
+    @IsString()
+    @IsOptional()
     description?: string;
 }

--- a/chat-ms/src/chat/chat.controller.ts
+++ b/chat-ms/src/chat/chat.controller.ts
@@ -11,7 +11,7 @@ import { CreateGroupDto } from './dto/create-group.dto';
 import { EditMessageDto } from './dto/edit-message.dto';
 import { DeleteMessageDto } from './dto/delete-message.dto';
 import { AddContactDto, UpdateContactDto, DeleteContactDto, GetContactsDto } from './dto/contact.dto';
-import { RemoveParticipantDto, PromoteToAdminDto, LeaveGroupDto, UpdateGroupDto } from './dto/group-management.dto';
+import { RemoveParticipantDto, PromoteToAdminDto, LeaveGroupDto, UpdateGroupDto, AddParticipantDto } from './dto/group-management.dto';
 
 @Controller()
 export class ChatController {
@@ -113,6 +113,11 @@ export class ChatController {
     @MessagePattern('remove_participant')
     removeParticipant(@Payload() data: RemoveParticipantDto) {
         return this.chatService.removeParticipant(data);
+    }
+
+    @MessagePattern('add_participant')
+    addParticipant(@Payload() data: AddParticipantDto) {
+        return this.chatService.addParticipant(data);
     }
 
     @MessagePattern('promote_to_admin')

--- a/chat-ms/src/chat/dto/group-management.dto.ts
+++ b/chat-ms/src/chat/dto/group-management.dto.ts
@@ -4,6 +4,12 @@ export class RemoveParticipantDto {
     userIdToRemove: string;
 }
 
+export class AddParticipantDto {
+    conversationId: string;
+    adminId: string;
+    userIdToAdd: string;
+}
+
 export class PromoteToAdminDto {
     conversationId: string;
     adminId: string;


### PR DESCRIPTION


- Added "Add Participant" functionality across API Gateway and Chat microservice.
- Fixed backend validation errors by adding missing class-validator decorators to group management DTOs.
- Enabled group description persistence and updates in the database.
- Implemented admin-only permission checks for adding, removing, and promoting participants.