### PR TITLE
Fix(chat): Validation decorators added to Group Management DTOs

### DIFF
--- a/chat-ms/src/chat/dto/group-management.dto.ts
+++ b/chat-ms/src/chat/dto/group-management.dto.ts
@@ -1,30 +1,75 @@
+import { IsString, IsOptional, IsNotEmpty } from 'class-validator';
+
 export class RemoveParticipantDto {
+    @IsString()
+    @IsNotEmpty()
     conversationId: string;
+
+    @IsString()
+    @IsNotEmpty()
     adminId: string;
+
+    @IsString()
+    @IsNotEmpty()
     userIdToRemove: string;
 }
 
 export class AddParticipantDto {
+    @IsString()
+    @IsNotEmpty()
     conversationId: string;
+
+    @IsString()
+    @IsNotEmpty()
     adminId: string;
+
+    @IsString()
+    @IsNotEmpty()
     userIdToAdd: string;
 }
 
 export class PromoteToAdminDto {
+    @IsString()
+    @IsNotEmpty()
     conversationId: string;
+
+    @IsString()
+    @IsNotEmpty()
     adminId: string;
+
+    @IsString()
+    @IsNotEmpty()
     userIdToPromote: string;
 }
 
 export class LeaveGroupDto {
+    @IsString()
+    @IsNotEmpty()
     conversationId: string;
+
+    @IsString()
+    @IsNotEmpty()
     userId: string;
 }
 
 export class UpdateGroupDto {
+    @IsString()
+    @IsNotEmpty()
     conversationId: string;
+
+    @IsString()
+    @IsNotEmpty()
     adminId: string;
+
+    @IsOptional()
+    @IsString()
     title?: string;
+
+    @IsOptional()
+    @IsString()
     imageUrl?: string;
+
+    @IsOptional()
+    @IsString()
     description?: string;
 }


### PR DESCRIPTION
El microservicio de chat (chat-ms) estaba rechazando las peticiones de gestión de grupos (salir, eliminar, promover) debido a una configuración estricta del ValidationPipe que descartaba propiedades no decoradas.

Cambios realizados:

Se añadieron los decoradores class-validator (@IsString, @IsNotEmpty, @IsOptional) a todos los DTOs en group-management.dto.ts:
RemoveParticipantDto
PromoteToAdminDto
LeaveGroupDto
UpdateGroupDto
AddParticipantDto
Esto sincroniza la validación interna del microservicio con la del API Gateway, permitiendo que las acciones fluyan correctamente sin errores de "property should not exist".