### PR TITLE
fix(forms): generate dual archive URLs for image and raw resource types

### DIFF
--- a/forms-ms/src/forms/cloudinary.service.ts
+++ b/forms-ms/src/forms/cloudinary.service.ts
@@ -42,26 +42,36 @@ export class CloudinaryService {
     }
 
     /**
-     * Generar un URL firmado para descargar un archivo ZIP con los recursos seleccionados
-     * Permite descargar por prefijo (carpeta) o lista de IDs.
+     * Generar URL(s) firmada(s) para descargar un ZIP con los recursos seleccionados.
+     * Retorna hasta dos URLs: una para resource_type=image y otra para resource_type=raw (PDFs).
+     * Cloudinary asigna el resource_type automáticamente al subir ('auto'), por lo que
+     * los PDFs pueden quedar como 'raw' y las imágenes como 'image'.
      */
-    generateArchiveUrl(options: { publicIds?: string[], prefix?: string, pageOneOnly?: boolean }): string {
-        const params: any = {
-            resource_type: 'image', // Cloudinary maneja PDFs como 'image' por defecto en 'auto'
+    generateArchiveUrls(options: { publicIds?: string[], prefix?: string }): { imageUrl: string; rawUrl: string } {
+        const base: any = {
             allow_missing: true,
             target_format: 'zip',
         };
 
+        const paramsImage: any = { ...base, resource_type: 'image' };
+        const paramsRaw: any   = { ...base, resource_type: 'raw' };
+
         if (options.publicIds && options.publicIds.length > 0) {
-            params.public_ids = options.publicIds;
+            paramsImage.public_ids = options.publicIds;
+            paramsRaw.public_ids   = options.publicIds;
         } else if (options.prefix) {
-            params.prefix = options.prefix;
+            paramsImage.prefix = options.prefix;
+            paramsRaw.prefix   = options.prefix;
         }
 
-        if (options.pageOneOnly) {
-            params.transformation = 'pg_1'; // Solo la primera página de cada PDF
-        }
+        return {
+            imageUrl: cloudinary.utils.download_archive_url(paramsImage),
+            rawUrl:   cloudinary.utils.download_archive_url(paramsRaw),
+        };
+    }
 
-        return cloudinary.utils.download_archive_url(params);
+    /** @deprecated — usar generateArchiveUrls */
+    generateArchiveUrl(options: { publicIds?: string[], prefix?: string, pageOneOnly?: boolean }): string {
+        return this.generateArchiveUrls(options).imageUrl;
     }
 }

--- a/forms-ms/src/forms/forms.service.ts
+++ b/forms-ms/src/forms/forms.service.ts
@@ -383,8 +383,6 @@ export class FormsService {
       throw new NotFoundException('No se encontraron documentos para los usuarios seleccionados.');
     }
 
-    return { 
-        url: this.cloudinaryService.generateArchiveUrl({ publicIds: [...new Set(publicIds)] }) 
-    };
+    return this.cloudinaryService.generateArchiveUrls({ publicIds: [...new Set(publicIds)] });
   }
 }


### PR DESCRIPTION
Cloudinary assigns resource_type automatically on upload ('auto'). PDFs end up as 'raw', images as 'image'. The previous implementation only generated a download_archive_url for resource_type=image, so only 12 files (images/some PDFs) were included in the ZIP instead of all 93.

generateArchiveUrls() now returns both imageUrl and rawUrl. The frontend opens both ZIPs sequentially (800ms apart to avoid popup blockers). Kept generateArchiveUrl() as deprecated alias for backward compat.