### PR TITLE
feat(chat-ms): implement native VoIP and FCM data-only push notifications

### DIFF
--- a/api-gateway/.dockerignore
+++ b/api-gateway/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.git
+.env

--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:22-alpine
+WORKDIR /app
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/package.json ./
+CMD ["npm", "run", "start:prod"]

--- a/api-gateway/src/Model-ms/dto/model.dto.ts
+++ b/api-gateway/src/Model-ms/dto/model.dto.ts
@@ -1,0 +1,33 @@
+import { IsString, IsNotEmpty, IsOptional, IsDateString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class TextToSpeechDto {
+    @ApiProperty({ example: 'Hola, ¿cómo estás?', description: 'Texto a convertir en voz' })
+    @IsString()
+    @IsNotEmpty()
+    text: string;
+}
+
+export class ConfirmWordDto {
+    @ApiProperty({ example: 'Seña', description: 'Palabra o seña confirmada' })
+    @IsString()
+    @IsNotEmpty()
+    word: string;
+
+    @ApiPropertyOptional({ example: 'user-uuid-123' })
+    @IsString()
+    @IsOptional()
+    userId?: string;
+
+    @ApiPropertyOptional({ example: '2025-05-06T12:00:00Z' })
+    @IsDateString()
+    @IsOptional()
+    timestamp?: Date;
+}
+
+export class TranscriptionDto {
+    @ApiProperty({ example: 'sala-123', description: 'Nombre de la sala para la transcripción' })
+    @IsString()
+    @IsNotEmpty()
+    room_name: string;
+}

--- a/api-gateway/src/Model-ms/model.controller.ts
+++ b/api-gateway/src/Model-ms/model.controller.ts
@@ -1,14 +1,20 @@
 import { Controller, Post, UploadedFile, UseInterceptors, Body, Res, StreamableFile, Header } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { ApiTags, ApiOperation, ApiResponse, ApiConsumes, ApiBearerAuth } from '@nestjs/swagger';
 import { ModelService } from './model.service';
 import { Response } from 'express';
+import { TextToSpeechDto, ConfirmWordDto, TranscriptionDto } from './dto/model.dto';
 
+@ApiTags('AI Models')
+@ApiBearerAuth()
 @Controller('model')
 export class ModelController {
     constructor(private readonly modelService: ModelService) { }
 
-    // POST /model/video-to-text
     @Post('video-to-text')
+    @ApiConsumes('multipart/form-data')
+    @ApiOperation({ summary: 'Convertir video (señas) a texto' })
+    @ApiResponse({ status: 200, description: 'Traducción exitosa' })
     @UseInterceptors(FileInterceptor('file'))
     async videoToText(
         @UploadedFile() file: Express.Multer.File
@@ -16,8 +22,10 @@ export class ModelController {
         return this.modelService.videoToText(file);
     }
 
-    // POST /model/video-to-audio
     @Post('video-to-audio')
+    @ApiConsumes('multipart/form-data')
+    @ApiOperation({ summary: 'Convertir video (señas) a audio' })
+    @ApiResponse({ status: 200, description: 'Conversión exitosa' })
     @UseInterceptors(FileInterceptor('file'))
     async videoToAudio(
         @UploadedFile() file?: Express.Multer.File
@@ -25,37 +33,39 @@ export class ModelController {
         return this.modelService.videoToAudio(file);
     }
 
-    // POST /model/tts
     @Post('tts')
+    @ApiOperation({ summary: 'Texto a Voz (TTS)' })
+    @ApiResponse({ status: 200, description: 'Audio generado' })
     async textToSpeech(
-        @Body() body: { text: string }
+        @Body() dto: TextToSpeechDto
     ) {
-        return this.modelService.textToSpeech(body.text);
+        return this.modelService.textToSpeech(dto.text);
     }
 
-    // POST /model/confirm-word
     @Post('confirm-word')
+    @ApiOperation({ summary: 'Confirmar palabra o seña detectada' })
+    @ApiResponse({ status: 200, description: 'Confirmación registrada' })
     async confirmWord(
-        @Body() body: { word: string; userId?: string; timestamp?: Date }
+        @Body() dto: ConfirmWordDto
     ) {
-        console.log(`🌐 [ModelController] HTTP POST /model/confirm-word recibido:`, body);
-        return this.modelService.confirmWord(body.word, body.userId, body.timestamp);
+        return this.modelService.confirmWord(dto.word, dto.userId, dto.timestamp);
     }
 
-    // POST /model/transcribe
     @Post('transcribe')
+    @ApiOperation({ summary: 'Iniciar transcripción en tiempo real de una sala' })
+    @ApiResponse({ status: 200, description: 'Transcripción iniciada' })
     async startTranscription(
-        @Body() body: { room_name: string }
+        @Body() dto: TranscriptionDto
     ) {
-        // Enforce snake_case from body if needed, or mapping
-        return this.modelService.startTranscription(body.room_name);
+        return this.modelService.startTranscription(dto.room_name);
     }
 
-    // POST /model/transcribe/stop
     @Post('transcribe/stop')
+    @ApiOperation({ summary: 'Detener transcripción de una sala' })
+    @ApiResponse({ status: 200, description: 'Transcripción detenida' })
     async stopTranscription(
-        @Body() body: { room_name: string }
+        @Body() dto: TranscriptionDto
     ) {
-        return this.modelService.stopTranscription(body.room_name);
+        return this.modelService.stopTranscription(dto.room_name);
     }
 }

--- a/api-gateway/src/auth/auth.controller.ts
+++ b/api-gateway/src/auth/auth.controller.ts
@@ -9,6 +9,9 @@ import { ResetPasswordDto } from './dto/reset-password.dto';
 import { UpdatePasswordDto } from './dto/update-password.dto';
 import { UpdateProfileDto } from './dto/update-profile.dto';
 import { UpdatePushTokenDto } from './dto/update-push-token.dto';
+import { LogoutDto } from './dto/logout.dto';
+import { VerifyTokenDto } from './dto/verify-token.dto';
+import { UpdateUserRoleDto } from './dto/update-user-role.dto';
 import { ApiTags, ApiOperation, ApiResponse, ApiBody, ApiBearerAuth } from '@nestjs/swagger';
 
 @ApiTags('Authentication')
@@ -117,22 +120,33 @@ export class AuthController {
     return this.client.send('update_push_token', data);
   }
 
+  @Post('update-voip-token')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Actualizar token VoIP (iOS)',
+    description: 'Guarda el token de PushKit para llamadas nativas.'
+  })
+  updateVoipToken(@Body() data: { userId: string; voipToken: string }) {
+    return this.client.send('update_voip_token', data);
+  }
+
+  @Post('update-fcm-token')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Actualizar token FCM (Android)',
+    description: 'Guarda el token de FCM para llamadas nativas por Data Message.'
+  })
+  updateFcmToken(@Body() data: { userId: string; fcmToken: string }) {
+    return this.client.send('update_fcm_token', data);
+  }
+
   @Post('logout')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: 'Cerrar sesión',
     description: 'Invalida el token del usuario y cierra todas sus sesiones activas en Supabase'
   })
-  @ApiBody({
-    schema: {
-      type: 'object',
-      properties: {
-        userId: { type: 'string', example: 'uuid-123' },
-        token: { type: 'string', example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...' }
-      },
-      required: ['userId', 'token']
-    }
-  })
+  @ApiBody({ type: LogoutDto })
   @ApiResponse({
     status: 200,
     description: 'Sesión cerrada exitosamente',
@@ -140,7 +154,7 @@ export class AuthController {
   })
   @ApiResponse({ status: 401, description: 'Token inválido o no corresponde al usuario' })
   @ApiResponse({ status: 400, description: 'Error al cerrar sesión' })
-  logout(@Body() logoutDto: { userId: string; token: string }) {
+  logout(@Body() logoutDto: LogoutDto) {
     return this.client.send('logout', logoutDto);
   }
 
@@ -244,7 +258,7 @@ export class AuthController {
     }
   })
   @ApiResponse({ status: 401, description: 'Token inválido, expirado o malformado' })
-  verifyToken(@Body() data: { token: string }) {
+  verifyToken(@Body() data: VerifyTokenDto) {
     return this.client.send('verify_token', data);
   }
 
@@ -390,9 +404,9 @@ export class AuthController {
   @Post('users/:userId/role')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Actualizar rol de usuario (Admin)' })
-  @ApiBody({ schema: { type: 'object', properties: { role: { type: 'string', enum: ['User', 'Admin', 'Interpreter'] } } } })
+  @ApiBody({ type: UpdateUserRoleDto })
   @ApiResponse({ status: 200, description: 'Rol actualizado exitosamente' })
-  updateUserRole(@Param('userId') userId: string, @Body() body: { role: string }) {
+  updateUserRole(@Param('userId') userId: string, @Body() body: UpdateUserRoleDto) {
     return this.client.send('update_role', { userId, role: body.role });
   }
 

--- a/api-gateway/src/auth/dto/login.dto.ts
+++ b/api-gateway/src/auth/dto/login.dto.ts
@@ -1,10 +1,13 @@
 import { IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class LoginDto {
+  @ApiProperty({ example: 'usuario@gmail.com', description: 'Correo electrónico del usuario' })
   @IsEmail({}, { message: 'El correo electrónico no es válido' })
   @IsNotEmpty({ message: 'El correo electrónico es requerido' })
   email: string;
 
+  @ApiProperty({ example: 'password123', description: 'Contraseña del usuario (mínimo 6 caracteres)', minLength: 6 })
   @IsString()
   @IsNotEmpty({ message: 'La contraseña es requerida' })
   @MinLength(6, { message: 'La contraseña debe tener al menos 6 caracteres' })

--- a/api-gateway/src/auth/dto/logout.dto.ts
+++ b/api-gateway/src/auth/dto/logout.dto.ts
@@ -1,0 +1,14 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class LogoutDto {
+  @ApiProperty({ example: 'uuid-123', description: 'ID del usuario que cierra sesión' })
+  @IsString()
+  @IsNotEmpty()
+  userId: string;
+
+  @ApiProperty({ example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...', description: 'Token JWT activo del usuario' })
+  @IsString()
+  @IsNotEmpty()
+  token: string;
+}

--- a/api-gateway/src/auth/dto/update-user-role.dto.ts
+++ b/api-gateway/src/auth/dto/update-user-role.dto.ts
@@ -1,0 +1,19 @@
+import { IsString, IsNotEmpty, IsEnum } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export enum UserRole {
+  USER = 'User',
+  ADMIN = 'Admin',
+  INTERPRETER = 'Interpreter',
+}
+
+export class UpdateUserRoleDto {
+  @ApiProperty({
+    enum: UserRole,
+    example: UserRole.INTERPRETER,
+    description: 'Nuevo rol del usuario',
+  })
+  @IsEnum(UserRole, { message: 'El rol debe ser User, Admin o Interpreter' })
+  @IsNotEmpty()
+  role: UserRole;
+}

--- a/api-gateway/src/auth/dto/verify-token.dto.ts
+++ b/api-gateway/src/auth/dto/verify-token.dto.ts
@@ -1,0 +1,9 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class VerifyTokenDto {
+  @ApiProperty({ example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...', description: 'Token JWT a verificar' })
+  @IsString()
+  @IsNotEmpty()
+  token: string;
+}

--- a/api-gateway/src/calls/calls.controller.ts
+++ b/api-gateway/src/calls/calls.controller.ts
@@ -1,6 +1,10 @@
 import { Controller, Post, Body, Inject } from '@nestjs/common';
 import { ClientProxy } from '@nestjs/microservices';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { GenerateTokenDto } from './dto/generate-token.dto';
 
+@ApiTags('Video Calls')
+@ApiBearerAuth()
 @Controller('calls')
 export class CallsController {
     constructor(
@@ -8,13 +12,12 @@ export class CallsController {
     ) { }
 
     @Post('token')
-    async getToken(
-        @Body('roomName') roomName: string,
-        @Body('username') username: string,
-    ) {
+    @ApiOperation({ summary: 'Generar token de acceso para video llamada' })
+    @ApiResponse({ status: 201, description: 'Token generado exitosamente' })
+    async getToken(@Body() dto: GenerateTokenDto) {
         return this.chatClient.send('generate_video_token', {
-            roomName: roomName || 'default-room',
-            username: username || 'Guest',
+            roomName: dto.roomName || 'default-room',
+            username: dto.username || 'Guest',
         });
     }
 }

--- a/api-gateway/src/calls/dto/generate-token.dto.ts
+++ b/api-gateway/src/calls/dto/generate-token.dto.ts
@@ -1,0 +1,14 @@
+import { IsString, IsNotEmpty, IsOptional } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class GenerateTokenDto {
+    @ApiProperty({ example: 'sala-emergencia-123', description: 'Nombre de la sala de video llamada' })
+    @IsString()
+    @IsNotEmpty()
+    roomName: string;
+
+    @ApiPropertyOptional({ example: 'Juan Pérez', description: 'Nombre que se mostrará en la llamada', default: 'Guest' })
+    @IsString()
+    @IsOptional()
+    username?: string;
+}

--- a/api-gateway/src/chat/chat.controller.ts
+++ b/api-gateway/src/chat/chat.controller.ts
@@ -11,6 +11,7 @@ import { SendChatMessageDto } from './dto/send-message.dto';
 import { GetMessagesDto, GetConversationsDto, MarkAsReadDto, EditMessageDto, DeleteMessageDto } from './dto/chat.dto';
 import { AddContactDto, UpdateContactDto } from './dto/contact.dto';
 import { RemoveParticipantDto, PromoteToAdminDto, LeaveGroupDto, UpdateGroupDto, AddParticipantDto } from './dto/group-management.dto';
+import { InviteInterpretersDto, SetInterpreterStatusDto, ClaimInterpreterInviteDto } from './dto/interpreter.dto';
 
 @ApiTags('Chat')
 @ApiBearerAuth()
@@ -162,21 +163,21 @@ export class ChatController {
     @HttpCode(HttpStatus.OK)
     @ApiOperation({ summary: 'Invitar intérpretes a una llamada' })
     @ApiResponse({ status: 200, description: 'Invitaciones enviadas' })
-    inviteInterpreters(@Body() dto: { roomName: string; userId: string; username: string }) {
+    inviteInterpreters(@Body() dto: InviteInterpretersDto) {
         return this.client.send('invite_interpreters', dto);
     }
 
     @Post('interpreter/status')
-    @ApiOperation({ summary: 'Update interpreter busy status' })
-    @ApiBody({ schema: { type: 'object', properties: { userId: { type: 'string' }, isBusy: { type: 'boolean' } } } })
-    setInterpreterStatus(@Body() body: { userId: string; isBusy: boolean }) {
+    @ApiOperation({ summary: 'Actualizar estado de disponibilidad del intérprete' })
+    @ApiBody({ type: SetInterpreterStatusDto })
+    setInterpreterStatus(@Body() body: SetInterpreterStatusDto) {
         return this.client.send('set_interpreter_status', body);
     }
 
     @Post('interpreter/claim')
     @ApiOperation({ summary: 'Reclamar una invitación de intérprete' })
-    @ApiBody({ schema: { type: 'object', properties: { inviteId: { type: 'string' }, userId: { type: 'string' } } } })
-    claimInterpreterInvite(@Body() body: { inviteId: string; userId: string }) {
+    @ApiBody({ type: ClaimInterpreterInviteDto })
+    claimInterpreterInvite(@Body() body: ClaimInterpreterInviteDto) {
         return this.client.send('claim_interpreter_invite', body);
     }
 

--- a/api-gateway/src/chat/dto/contact.dto.ts
+++ b/api-gateway/src/chat/dto/contact.dto.ts
@@ -39,8 +39,11 @@ export class UpdateContactDto {
     @IsOptional()
     customFirstName?: string;
 
+    @ApiPropertyOptional({ description: 'Apellido personalizado' })
+    @IsString()
     @IsOptional()
     customLastName?: string;
+
 }
 
 export class GetContactsDto {

--- a/api-gateway/src/chat/dto/interpreter.dto.ts
+++ b/api-gateway/src/chat/dto/interpreter.dto.ts
@@ -1,0 +1,42 @@
+import { IsString, IsNotEmpty, IsBoolean } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class InviteInterpretersDto {
+  @ApiProperty({ example: 'sala-123', description: 'Nombre de la sala de llamada' })
+  @IsString()
+  @IsNotEmpty()
+  roomName: string;
+
+  @ApiProperty({ example: 'uuid-456', description: 'ID del usuario que solicita el intérprete' })
+  @IsString()
+  @IsNotEmpty()
+  userId: string;
+
+  @ApiProperty({ example: 'Juan Pérez', description: 'Nombre de usuario que aparece en la invitación' })
+  @IsString()
+  @IsNotEmpty()
+  username: string;
+}
+
+export class SetInterpreterStatusDto {
+  @ApiProperty({ example: 'uuid-789', description: 'ID del intérprete' })
+  @IsString()
+  @IsNotEmpty()
+  userId: string;
+
+  @ApiProperty({ example: false, description: 'true si el intérprete está ocupado, false si está disponible' })
+  @IsBoolean()
+  isBusy: boolean;
+}
+
+export class ClaimInterpreterInviteDto {
+  @ApiProperty({ example: 'invite-uuid-123', description: 'ID de la invitación a reclamar' })
+  @IsString()
+  @IsNotEmpty()
+  inviteId: string;
+
+  @ApiProperty({ example: 'uuid-789', description: 'ID del intérprete que reclama la invitación' })
+  @IsString()
+  @IsNotEmpty()
+  userId: string;
+}

--- a/api-gateway/src/communication/communication.controller.ts
+++ b/api-gateway/src/communication/communication.controller.ts
@@ -1,13 +1,14 @@
 import { Controller, Get, Post, Put, Delete, Body, Param, Query } from '@nestjs/common';
 import { ClientProxy } from '@nestjs/microservices';
 import { Inject } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery, ApiBearerAuth } from '@nestjs/swagger';
 import { CommunicationService } from './communication.service';
-import { SendMessageDto } from './dto/send-message.dto';
-import { CreateAppNotificationDto, UpdateAppNotificationDto } from './dto/app-notification.dto';
+import { SendMessageDto, UpdateMessageDto } from './dto/send-message.dto';
+import { CreateAppNotificationDto, UpdateAppNotificationDto, CreateNotificationCategoryDto, UpdateNotificationCategoryDto, PushTestDto, MarkReadBodyDto } from './dto/app-notification.dto';
 
-@Controller('communication')
 @ApiTags('Communication')
+@ApiBearerAuth()
+@Controller('communication')
 export class CommunicationController {
   constructor(
     @Inject('COMMUNICATION_SERVICE') private readonly client: ClientProxy,
@@ -15,26 +16,39 @@ export class CommunicationController {
   ) { }
 
   @Post('send')
+  @ApiOperation({ summary: 'Enviar un mensaje (Email, SMS, Push, In-App)' })
+  @ApiResponse({ status: 201, description: 'Mensaje enviado correctamente' })
   send(@Body() sendDto: SendMessageDto) {
     return this.client.send('send_message', sendDto);
   }
 
   @Get()
+  @ApiOperation({ summary: 'Obtener historial de mensajes enviados' })
+  @ApiResponse({ status: 200, description: 'Lista de mensajes' })
   findAll() {
     return this.client.send('find_all_messages', {});
   }
 
   @Get(':id')
+  @ApiOperation({ summary: 'Obtener un mensaje específico por ID' })
+  @ApiParam({ name: 'id', description: 'ID del mensaje' })
+  @ApiResponse({ status: 200, description: 'Detalle del mensaje' })
   findOne(@Param('id') id: string) {
     return this.client.send('find_one_message', { id });
   }
 
   @Put(':id')
-  update(@Param('id') id: string, @Body() updateDto: any) {
+  @ApiOperation({ summary: 'Actualizar un mensaje' })
+  @ApiParam({ name: 'id', description: 'ID del mensaje' })
+  @ApiResponse({ status: 200, description: 'Mensaje actualizado' })
+  update(@Param('id') id: string, @Body() updateDto: UpdateMessageDto) {
     return this.client.send('update_message', { id, updateData: updateDto });
   }
 
   @Delete(':id')
+  @ApiOperation({ summary: 'Eliminar un mensaje del historial' })
+  @ApiParam({ name: 'id', description: 'ID del mensaje' })
+  @ApiResponse({ status: 200, description: 'Mensaje eliminado' })
   remove(@Param('id') id: string) {
     return this.client.send('delete_message', { id });
   }
@@ -42,8 +56,9 @@ export class CommunicationController {
 
 // ==================== App Notifications Controller ====================
 
-@Controller('notifications')
 @ApiTags('App Notifications')
+@ApiBearerAuth()
+@Controller('notifications')
 export class AppNotificationsController {
   constructor(
     @Inject('COMMUNICATION_SERVICE') private readonly client: ClientProxy,
@@ -69,7 +84,7 @@ export class AppNotificationsController {
   @ApiOperation({ summary: 'Marcar notificación como leída' })
   @ApiParam({ name: 'id', description: 'ID de la notificación' })
   @ApiResponse({ status: 200, description: 'Marcada como leída' })
-  markAsRead(@Param('id') notificationId: string, @Body() body: { userId: string }) {
+  markAsRead(@Param('id') notificationId: string, @Body() body: MarkReadBodyDto) {
     return this.client.send('mark_notification_read', { userId: body.userId, notificationId });
   }
 
@@ -125,7 +140,7 @@ export class AppNotificationsController {
   @Post('categories')
   @ApiOperation({ summary: '[Admin] Crear categoría de notificación' })
   @ApiResponse({ status: 201, description: 'Categoría creada' })
-  createCategory(@Body() dto: any) {
+  createCategory(@Body() dto: CreateNotificationCategoryDto) {
     return this.client.send('create_notification_category', dto);
   }
 
@@ -133,7 +148,7 @@ export class AppNotificationsController {
   @ApiOperation({ summary: '[Admin] Actualizar categoría' })
   @ApiParam({ name: 'id', description: 'ID de la categoría' })
   @ApiResponse({ status: 200, description: 'Categoría actualizada' })
-  updateCategory(@Param('id') id: string, @Body() dto: any) {
+  updateCategory(@Param('id') id: string, @Body() dto: UpdateNotificationCategoryDto) {
     return this.client.send('update_notification_category', { id, dto });
   }
 
@@ -150,7 +165,7 @@ export class AppNotificationsController {
   @Post('push-test')
   @ApiOperation({ summary: 'Enviar notificación push de prueba' })
   @ApiResponse({ status: 200, description: 'Notificación enviada' })
-  sendPushTest(@Body() body: { userId: string; token: string }) {
+  sendPushTest(@Body() body: PushTestDto) {
     return this.client.send('send_push_notification', {
       to: body.token,
       title: 'Prueba Tincadia',

--- a/api-gateway/src/communication/dto/app-notification.dto.ts
+++ b/api-gateway/src/communication/dto/app-notification.dto.ts
@@ -149,7 +149,24 @@ export class UpdateNotificationCategoryDto {
     icon?: string;
 
     @ApiPropertyOptional()
+    @ApiPropertyOptional()
     @IsOptional()
     @IsBoolean()
     isActive?: boolean;
+}
+
+export class PushTestDto {
+    @ApiProperty({ example: 'user-uuid-123', description: 'ID del usuario destinatario' })
+    @IsString()
+    userId: string;
+
+    @ApiProperty({ example: 'expo-push-token', description: 'Token de notificación push' })
+    @IsString()
+    token: string;
+}
+
+export class MarkReadBodyDto {
+    @ApiProperty({ example: 'user-uuid-123', description: 'ID del usuario' })
+    @IsString()
+    userId: string;
 }

--- a/api-gateway/src/communication/dto/send-message.dto.ts
+++ b/api-gateway/src/communication/dto/send-message.dto.ts
@@ -1,4 +1,5 @@
-import { IsEmail, IsEnum, IsNotEmpty, IsString, IsObject, IsOptional, IsArray } from 'class-validator';
+import { IsEmail, IsEnum, IsNotEmpty, IsString, IsObject, IsOptional } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export enum MessageType {
   EMAIL = 'email',
@@ -8,26 +9,68 @@ export enum MessageType {
 }
 
 export class SendMessageDto {
+  @ApiProperty({
+    enum: MessageType,
+    example: MessageType.EMAIL,
+    description: 'Tipo de mensaje a enviar'
+  })
   @IsEnum(MessageType)
   @IsNotEmpty()
   type: MessageType;
 
+  @ApiProperty({ example: 'usuario@ejemplo.com', description: 'Destinatario del mensaje' })
   @IsEmail()
   @IsNotEmpty()
   to: string;
 
+  @ApiProperty({ example: 'Bienvenido a Tincadia', description: 'Asunto del mensaje' })
   @IsString()
   @IsNotEmpty()
   subject: string;
 
+  @ApiProperty({ example: '<p>Hola!</p>', description: 'Contenido del mensaje (HTML o texto)' })
   @IsString()
   @IsNotEmpty()
   content: string;
 
+  @ApiPropertyOptional({ example: 'noreply@tincadia.com', description: 'Remitente (opcional)' })
   @IsString()
   @IsOptional()
   from?: string;
 
+  @ApiPropertyOptional({ description: 'Metadatos adicionales para el mensaje' })
+  @IsObject()
+  @IsOptional()
+  metadata?: Record<string, any>;
+}
+
+export class UpdateMessageDto {
+  @ApiPropertyOptional({ enum: MessageType })
+  @IsEnum(MessageType)
+  @IsOptional()
+  type?: MessageType;
+
+  @ApiPropertyOptional({ example: 'usuario@ejemplo.com' })
+  @IsEmail()
+  @IsOptional()
+  to?: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  subject?: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  content?: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  from?: string;
+
+  @ApiPropertyOptional()
   @IsObject()
   @IsOptional()
   metadata?: Record<string, any>;

--- a/api-gateway/src/contacts/contacts.controller.ts
+++ b/api-gateway/src/contacts/contacts.controller.ts
@@ -15,6 +15,7 @@ import { lastValueFrom } from 'rxjs';
 import { StartContactsSyncDto } from './dto/start-contacts-sync.dto';
 import { ContactsSyncChunkDto } from './dto/contacts-sync-chunk.dto';
 import { CompleteContactsSyncDto } from './dto/complete-contacts-sync.dto';
+import { BatchIdDto } from './dto/batch-id.dto';
 
 @ApiTags('Contacts')
 @Controller('contacts/sync')
@@ -26,17 +27,17 @@ export class ContactsController {
 
   private async getUserIdFromAuthHeader(authHeader?: string): Promise<string> {
     if (!authHeader) {
-      throw new UnauthorizedException('Authorization header is required');
+      throw new UnauthorizedException('El encabezado de autorización es requerido');
     }
     const token = authHeader.replace('Bearer ', '').trim();
     if (!token) {
-      throw new UnauthorizedException('Token is required');
+      throw new UnauthorizedException('El token es requerido');
     }
 
     const res = await lastValueFrom(this.authClient.send('verify_token', { token }));
     const userId = res?.user?.id;
     if (!userId) {
-      throw new UnauthorizedException('Invalid or expired token');
+      throw new UnauthorizedException('Token inválido o expirado');
     }
     return userId;
   }
@@ -92,7 +93,7 @@ export class ContactsController {
   @HttpCode(HttpStatus.OK)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Pausar sincronización' })
-  pause(@Headers('authorization') authHeader: string, @Body() body: { batchId: string }) {
+  pause(@Headers('authorization') authHeader: string, @Body() body: BatchIdDto) {
     return (async () => {
       const userId = await this.getUserIdFromAuthHeader(authHeader);
       return lastValueFrom(this.contactsClient.send('contacts_sync_pause', { userId, ...body }));
@@ -103,7 +104,7 @@ export class ContactsController {
   @HttpCode(HttpStatus.OK)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Reanudar sincronización' })
-  resume(@Headers('authorization') authHeader: string, @Body() body: { batchId: string }) {
+  resume(@Headers('authorization') authHeader: string, @Body() body: BatchIdDto) {
     return (async () => {
       const userId = await this.getUserIdFromAuthHeader(authHeader);
       return lastValueFrom(this.contactsClient.send('contacts_sync_resume', { userId, ...body }));

--- a/api-gateway/src/contacts/dto/batch-id.dto.ts
+++ b/api-gateway/src/contacts/dto/batch-id.dto.ts
@@ -1,0 +1,9 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class BatchIdDto {
+    @ApiProperty({ example: 'batch-uuid-123', description: 'ID del lote de sincronización' })
+    @IsString()
+    @IsNotEmpty()
+    batchId: string;
+}

--- a/api-gateway/src/content/content.controller.ts
+++ b/api-gateway/src/content/content.controller.ts
@@ -2,9 +2,17 @@ import { Controller, Get, Post, Put, Delete, Body, Inject, UseInterceptors, Uplo
 import { ClientProxy } from '@nestjs/microservices';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { FileInterceptor } from '@nestjs/platform-express';
-// ...
+import {
+    CreateCategoryDto, UpdateCategoryDto,
+    CreateCourseDto, UpdateCourseDto,
+    CreateModuleDto, UpdateModuleDto,
+    CreateLessonDto, UpdateLessonDto,
+    CreateTestimonialDto, UpdateTestimonialDto,
+    CreateFaqDto, UpdateFaqDto,
+} from './dto/content.dto';
+
 @Controller('content')
-@ApiTags('content')
+@ApiTags('Content')
 export class ContentController {
     constructor(
         @Inject('CONTENT_SERVICE') private readonly client: ClientProxy,
@@ -25,13 +33,13 @@ export class ContentController {
 
     @Post('categories')
     @ApiOperation({ summary: 'Create a new category' })
-    async createCategory(@Body() data: any) {
+    async createCategory(@Body() data: CreateCategoryDto) {
         return this.client.send('createCategory', data);
     }
 
     @Put('categories/:id')
     @ApiOperation({ summary: 'Update category' })
-    async updateCategory(@Param('id') id: string, @Body() data: any) {
+    async updateCategory(@Param('id') id: string, @Body() data: UpdateCategoryDto) {
         return this.client.send('updateCategory', { id, updateData: data });
     }
 
@@ -45,13 +53,13 @@ export class ContentController {
 
     @Post('courses')
     @ApiOperation({ summary: 'Create a new course' })
-    async create(@Body() data: any) {
+    async create(@Body() data: CreateCourseDto) {
         return this.client.send('createCourse', data);
     }
 
     @Put('courses/:id')
     @ApiOperation({ summary: 'Update course' })
-    async update(@Param('id') id: string, @Body() data: any) {
+    async update(@Param('id') id: string, @Body() data: UpdateCourseDto) {
         return this.client.send('updateCourse', { id, updateData: data });
     }
 
@@ -72,13 +80,13 @@ export class ContentController {
 
     @Post('courses/:courseId/modules')
     @ApiOperation({ summary: 'Create a module for a course' })
-    async createModule(@Param('courseId') courseId: string, @Body() data: any) {
+    async createModule(@Param('courseId') courseId: string, @Body() data: CreateModuleDto) {
         return this.client.send('createModule', { ...data, courseId });
     }
 
     @Put('modules/:id')
     @ApiOperation({ summary: 'Update module' })
-    async updateModule(@Param('id') id: string, @Body() data: any) {
+    async updateModule(@Param('id') id: string, @Body() data: UpdateModuleDto) {
         return this.client.send('updateModule', { id, updateData: data });
     }
 
@@ -92,13 +100,13 @@ export class ContentController {
 
     @Post('modules/:moduleId/lessons')
     @ApiOperation({ summary: 'Create a lesson for a module' })
-    async createLesson(@Param('moduleId') moduleId: string, @Body() data: any) {
+    async createLesson(@Param('moduleId') moduleId: string, @Body() data: CreateLessonDto) {
         return this.client.send('createLesson', { ...data, moduleId });
     }
 
     @Put('lessons/:id')
     @ApiOperation({ summary: 'Update lesson' })
-    async updateLesson(@Param('id') id: string, @Body() data: any) {
+    async updateLesson(@Param('id') id: string, @Body() data: UpdateLessonDto) {
         return this.client.send('updateLesson', { id, updateData: data });
     }
 
@@ -219,13 +227,13 @@ export class ContentController {
 
     @Post('testimonials')
     @ApiOperation({ summary: 'Create testimonial' })
-    async createTestimonial(@Body() data: any) {
+    async createTestimonial(@Body() data: CreateTestimonialDto) {
         return this.client.send('create_testimonial', data);
     }
 
     @Put('testimonials/:id')
     @ApiOperation({ summary: 'Update testimonial' })
-    async updateTestimonial(@Param('id') id: string, @Body() data: any) {
+    async updateTestimonial(@Param('id') id: string, @Body() data: UpdateTestimonialDto) {
         return this.client.send('update_testimonial', { ...data, id });
     }
 
@@ -251,13 +259,13 @@ export class ContentController {
 
     @Post('faqs')
     @ApiOperation({ summary: 'Create faq' })
-    async createFaq(@Body() data: any) {
+    async createFaq(@Body() data: CreateFaqDto) {
         return this.client.send('create_faq', data);
     }
 
     @Put('faqs/:id')
     @ApiOperation({ summary: 'Update faq' })
-    async updateFaq(@Param('id') id: string, @Body() data: any) {
+    async updateFaq(@Param('id') id: string, @Body() data: UpdateFaqDto) {
         return this.client.send('update_faq', { ...data, id });
     }
 

--- a/api-gateway/src/content/dto/content.dto.ts
+++ b/api-gateway/src/content/dto/content.dto.ts
@@ -1,0 +1,351 @@
+import { IsString, IsNotEmpty, IsOptional, IsBoolean, IsUUID, IsInt, IsArray, Min } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+// ===================== CATEGORY =====================
+
+export class CreateCategoryDto {
+    @ApiProperty({ example: 'Lengua de Señas Colombiana', description: 'Nombre de la categoría' })
+    @IsString()
+    @IsNotEmpty()
+    name: string;
+
+    @ApiPropertyOptional({ example: 'Cursos relacionados con LSC', description: 'Descripción de la categoría' })
+    @IsString()
+    @IsOptional()
+    description?: string;
+}
+
+export class UpdateCategoryDto {
+    @ApiPropertyOptional({ example: 'LSC Avanzado', description: 'Nuevo nombre de la categoría' })
+    @IsString()
+    @IsOptional()
+    name?: string;
+
+    @ApiPropertyOptional({ example: 'Contenido avanzado de LSC', description: 'Nueva descripción' })
+    @IsString()
+    @IsOptional()
+    description?: string;
+}
+
+// ===================== COURSE =====================
+
+export class CreateCourseDto {
+    @ApiProperty({ example: 'Introducción a la LSC', description: 'Título del curso' })
+    @IsString()
+    @IsNotEmpty()
+    title: string;
+
+    @ApiPropertyOptional({ example: 'Aprende los fundamentos de la Lengua de Señas Colombiana', description: 'Descripción del curso' })
+    @IsString()
+    @IsOptional()
+    description?: string;
+
+    @ApiProperty({ example: 'uuid-categoria-123', description: 'ID de la categoría a la que pertenece el curso' })
+    @IsUUID()
+    @IsNotEmpty()
+    categoryId: string;
+
+    @ApiPropertyOptional({ example: false, description: 'Si el curso está publicado y visible para los usuarios' })
+    @IsBoolean()
+    @IsOptional()
+    isPublished?: boolean;
+
+    @ApiPropertyOptional({
+        example: 'free',
+        description: 'Scope de acceso: free | course | module | lesson',
+        enum: ['free', 'course', 'module', 'lesson'],
+    })
+    @IsString()
+    @IsOptional()
+    accessScope?: string;
+
+    @ApiPropertyOptional({ example: false, description: 'Si el curso completo es de pago' })
+    @IsBoolean()
+    @IsOptional()
+    isPaid?: boolean;
+
+    @ApiPropertyOptional({ example: 3, description: 'Número de lecciones disponibles como vista previa gratuita' })
+    @IsInt()
+    @IsOptional()
+    @Type(() => Number)
+    previewLimit?: number;
+
+    @ApiPropertyOptional({ example: ['Aprenderás el alfabeto', 'Comunicación básica'], description: 'Lista de puntos de aprendizaje' })
+    @IsArray()
+    @IsOptional()
+    learningPoints?: string[];
+}
+
+export class UpdateCourseDto {
+    @ApiPropertyOptional({ example: 'LSC Intermedio', description: 'Nuevo título del curso' })
+    @IsString()
+    @IsOptional()
+    title?: string;
+
+    @ApiPropertyOptional({ example: 'Nivel intermedio de LSC', description: 'Nueva descripción del curso' })
+    @IsString()
+    @IsOptional()
+    description?: string;
+
+    @ApiPropertyOptional({ example: 'uuid-categoria-456', description: 'Nueva categoría del curso' })
+    @IsUUID()
+    @IsOptional()
+    categoryId?: string;
+
+    @ApiPropertyOptional({ example: true, description: 'Estado de publicación del curso' })
+    @IsBoolean()
+    @IsOptional()
+    isPublished?: boolean;
+
+    @ApiPropertyOptional({ example: 'module', enum: ['free', 'course', 'module', 'lesson'] })
+    @IsString()
+    @IsOptional()
+    accessScope?: string;
+
+    @ApiPropertyOptional({ example: false })
+    @IsBoolean()
+    @IsOptional()
+    isPaid?: boolean;
+
+    @ApiPropertyOptional({ example: 4 })
+    @IsInt()
+    @IsOptional()
+    @Type(() => Number)
+    previewLimit?: number;
+
+    @ApiPropertyOptional({ example: ['Vocabulario avanzado', 'Gramática de señas'] })
+    @IsArray()
+    @IsOptional()
+    learningPoints?: string[];
+}
+
+// ===================== MODULE =====================
+
+export class CreateModuleDto {
+    @ApiProperty({ example: 'Módulo 1: Fundamentos', description: 'Título del módulo' })
+    @IsString()
+    @IsNotEmpty()
+    title: string;
+
+    @ApiPropertyOptional({ example: 'Introducción a los conceptos básicos', description: 'Descripción del módulo' })
+    @IsString()
+    @IsOptional()
+    description?: string;
+
+    @ApiPropertyOptional({ example: 0, description: 'Orden del módulo dentro del curso', minimum: 0 })
+    @IsInt()
+    @Min(0)
+    @IsOptional()
+    @Type(() => Number)
+    order?: number;
+
+    @ApiPropertyOptional({ example: false, description: 'Si el módulo completo requiere pago' })
+    @IsBoolean()
+    @IsOptional()
+    isPaid?: boolean;
+}
+
+export class UpdateModuleDto {
+    @ApiPropertyOptional({ example: 'Módulo 2: Vocabulario', description: 'Nuevo título del módulo' })
+    @IsString()
+    @IsOptional()
+    title?: string;
+
+    @ApiPropertyOptional({ example: 'Vocabulario cotidiano en señas', description: 'Nueva descripción del módulo' })
+    @IsString()
+    @IsOptional()
+    description?: string;
+
+    @ApiPropertyOptional({ example: 1, minimum: 0 })
+    @IsInt()
+    @Min(0)
+    @IsOptional()
+    @Type(() => Number)
+    order?: number;
+
+    @ApiPropertyOptional({ example: true })
+    @IsBoolean()
+    @IsOptional()
+    isPaid?: boolean;
+}
+
+// ===================== LESSON =====================
+
+export class CreateLessonDto {
+    @ApiProperty({ example: 'Lección 1: El alfabeto', description: 'Título de la lección' })
+    @IsString()
+    @IsNotEmpty()
+    title: string;
+
+    @ApiPropertyOptional({ example: 'En esta lección aprenderás el alfabeto manual completo.', description: 'Contenido descriptivo de la lección' })
+    @IsString()
+    @IsOptional()
+    content?: string;
+
+    @ApiPropertyOptional({ example: 'https://res.cloudinary.com/...', description: 'URL del video en Cloudinary' })
+    @IsString()
+    @IsOptional()
+    videoUrl?: string;
+
+    @ApiPropertyOptional({ example: 300, description: 'Duración del video en segundos' })
+    @IsInt()
+    @IsOptional()
+    @Type(() => Number)
+    durationSeconds?: number;
+
+    @ApiPropertyOptional({ example: 0, description: 'Orden de la lección dentro del módulo', minimum: 0 })
+    @IsInt()
+    @Min(0)
+    @IsOptional()
+    @Type(() => Number)
+    order?: number;
+
+    @ApiPropertyOptional({ example: false, description: 'Si la lección requiere pago para ver el video' })
+    @IsBoolean()
+    @IsOptional()
+    isPaid?: boolean;
+
+    @ApiPropertyOptional({ example: true, description: 'Si la lección es una vista previa gratuita aunque el curso sea de pago' })
+    @IsBoolean()
+    @IsOptional()
+    isFreePreview?: boolean;
+}
+
+export class UpdateLessonDto {
+    @ApiPropertyOptional({ example: 'Lección 1 actualizada', description: 'Nuevo título de la lección' })
+    @IsString()
+    @IsOptional()
+    title?: string;
+
+    @ApiPropertyOptional({ example: 'Contenido actualizado de la lección.' })
+    @IsString()
+    @IsOptional()
+    content?: string;
+
+    @ApiPropertyOptional({ example: 'https://res.cloudinary.com/nuevo-video...' })
+    @IsString()
+    @IsOptional()
+    videoUrl?: string;
+
+    @ApiPropertyOptional({ example: 420 })
+    @IsInt()
+    @IsOptional()
+    @Type(() => Number)
+    durationSeconds?: number;
+
+    @ApiPropertyOptional({ example: 1, minimum: 0 })
+    @IsInt()
+    @Min(0)
+    @IsOptional()
+    @Type(() => Number)
+    order?: number;
+
+    @ApiPropertyOptional({ example: true })
+    @IsBoolean()
+    @IsOptional()
+    isPaid?: boolean;
+
+    @ApiPropertyOptional({ example: false })
+    @IsBoolean()
+    @IsOptional()
+    isFreePreview?: boolean;
+}
+
+// ===================== TESTIMONIAL =====================
+
+export class CreateTestimonialDto {
+    @ApiProperty({ example: 'María García', description: 'Nombre de la persona que da el testimonio' })
+    @IsString()
+    @IsNotEmpty()
+    name: string;
+
+    @ApiPropertyOptional({ example: 'Docente de primaria', description: 'Rol o profesión del autor del testimonio' })
+    @IsString()
+    @IsOptional()
+    role?: string;
+
+    @ApiProperty({ example: 'Tincadia me ayudó a comunicarme con mis estudiantes sordos.', description: 'Texto del testimonio' })
+    @IsString()
+    @IsNotEmpty()
+    content: string;
+
+    @ApiPropertyOptional({ example: 'https://res.cloudinary.com/avatar.jpg', description: 'URL de la foto del autor' })
+    @IsString()
+    @IsOptional()
+    avatarUrl?: string;
+
+    @ApiPropertyOptional({ example: 5, description: 'Calificación de 1 a 5' })
+    @IsInt()
+    @IsOptional()
+    @Type(() => Number)
+    rating?: number;
+}
+
+export class UpdateTestimonialDto {
+    @ApiPropertyOptional({ example: 'Carlos López' })
+    @IsString()
+    @IsOptional()
+    name?: string;
+
+    @ApiPropertyOptional({ example: 'Ingeniero de sistemas' })
+    @IsString()
+    @IsOptional()
+    role?: string;
+
+    @ApiPropertyOptional({ example: 'La mejor plataforma de lengua de señas.' })
+    @IsString()
+    @IsOptional()
+    content?: string;
+
+    @ApiPropertyOptional({ example: 'https://res.cloudinary.com/nuevo-avatar.jpg' })
+    @IsString()
+    @IsOptional()
+    avatarUrl?: string;
+
+    @ApiPropertyOptional({ example: 4 })
+    @IsInt()
+    @IsOptional()
+    @Type(() => Number)
+    rating?: number;
+}
+
+// ===================== FAQ =====================
+
+export class CreateFaqDto {
+    @ApiProperty({ example: '¿Tincadia tiene versión gratuita?', description: 'Pregunta de la FAQ' })
+    @IsString()
+    @IsNotEmpty()
+    question: string;
+
+    @ApiProperty({ example: 'Sí, Tincadia ofrece acceso gratuito a contenido básico.', description: 'Respuesta a la pregunta' })
+    @IsString()
+    @IsNotEmpty()
+    answer: string;
+
+    @ApiPropertyOptional({ example: 0, description: 'Orden de aparición de la FAQ', minimum: 0 })
+    @IsInt()
+    @Min(0)
+    @IsOptional()
+    @Type(() => Number)
+    order?: number;
+}
+
+export class UpdateFaqDto {
+    @ApiPropertyOptional({ example: '¿Puedo usar Tincadia offline?' })
+    @IsString()
+    @IsOptional()
+    question?: string;
+
+    @ApiPropertyOptional({ example: 'Actualmente Tincadia requiere conexión a internet.' })
+    @IsString()
+    @IsOptional()
+    answer?: string;
+
+    @ApiPropertyOptional({ example: 1, minimum: 0 })
+    @IsInt()
+    @Min(0)
+    @IsOptional()
+    @Type(() => Number)
+    order?: number;
+}

--- a/api-gateway/src/emergency/dto/generate-audio.dto.ts
+++ b/api-gateway/src/emergency/dto/generate-audio.dto.ts
@@ -1,0 +1,33 @@
+import { IsString, IsNotEmpty, IsOptional, IsIn } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class GenerateAudioDto {
+    @ApiProperty({
+        example: 'incendio',
+        description: 'Tipo de emergencia',
+        enum: ['incendio', 'robo', 'accidente', 'medica', 'otro'],
+    })
+    @IsString()
+    @IsNotEmpty()
+    @IsIn(['incendio', 'robo', 'accidente', 'medica', 'otro'])
+    emergencyType: string;
+
+    @ApiProperty({
+        example: 'Calle 72 con Carrera 15, Bogotá',
+        description: 'Ubicación de la emergencia (dirección o coordenadas)',
+    })
+    @IsString()
+    @IsNotEmpty()
+    location: string;
+
+    @ApiPropertyOptional({
+        example: 'es',
+        description: 'Idioma del audio generado. Por defecto español.',
+        enum: ['es', 'en', 'pt'],
+        default: 'es',
+    })
+    @IsString()
+    @IsIn(['es', 'en', 'pt'])
+    @IsOptional()
+    language?: string;
+}

--- a/api-gateway/src/emergency/emergency.controller.ts
+++ b/api-gateway/src/emergency/emergency.controller.ts
@@ -1,7 +1,11 @@
 import { Controller, Post, Body, Inject, BadRequestException } from '@nestjs/common';
 import { ClientProxy } from '@nestjs/microservices';
 import { firstValueFrom } from 'rxjs';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { GenerateAudioDto } from './dto/generate-audio.dto';
 
+@ApiTags('Emergency')
+@ApiBearerAuth()
 @Controller('emergency')
 export class EmergencyController {
     constructor(
@@ -9,13 +13,19 @@ export class EmergencyController {
     ) { }
 
     @Post('generate-audio')
-    async generateAudio(@Body() body: { emergencyType: string; location: string; language?: string }) {
+    @ApiOperation({
+        summary: 'Generar audio de emergencia',
+        description: 'Genera un audio de alerta para el tipo de emergencia indicado. Útil para usuarios con discapacidad auditiva que necesitan comunicar una emergencia a terceros.'
+    })
+    @ApiResponse({ status: 201, description: 'Audio generado exitosamente', schema: { example: { audioUrl: 'https://res.cloudinary.com/.../emergencia_incendio.mp3' } } })
+    @ApiResponse({ status: 400, description: 'Error al generar el audio de emergencia' })
+    async generateAudio(@Body() dto: GenerateAudioDto) {
         try {
             return await firstValueFrom(
-                this.emergencyClient.send({ cmd: 'generate-emergency-audio' }, body),
+                this.emergencyClient.send({ cmd: 'generate-emergency-audio' }, dto),
             );
         } catch (error) {
-            throw new BadRequestException(error.message || 'Error generating emergency audio');
+            throw new BadRequestException(error.message || 'Error al generar el audio de emergencia');
         }
     }
 }

--- a/api-gateway/src/forms/dto/forms.dto.ts
+++ b/api-gateway/src/forms/dto/forms.dto.ts
@@ -1,0 +1,42 @@
+import { IsString, IsNotEmpty, IsOptional, IsObject, IsUUID } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateFormDto {
+    @ApiPropertyOptional({ example: 'Nuevo Título del Formulario' })
+    @IsString()
+    @IsOptional()
+    title?: string;
+
+    @ApiPropertyOptional({ example: 'Nueva descripción' })
+    @IsString()
+    @IsOptional()
+    description?: string;
+
+    @ApiPropertyOptional({ example: [] })
+    @IsOptional()
+    fields?: any[];
+}
+
+export class SubmitFormDto {
+    @ApiProperty({ example: 'form-uuid-123', description: 'ID del formulario' })
+    @IsUUID()
+    @IsNotEmpty()
+    formId: string;
+
+    @ApiProperty({ example: 'user-uuid-456', description: 'ID del usuario que envía' })
+    @IsString()
+    @IsNotEmpty()
+    submittedBy: string;
+
+    @ApiProperty({ example: { nombre: 'Juan', edad: 30 }, description: 'Datos del formulario' })
+    @IsObject()
+    @IsNotEmpty()
+    data: any;
+}
+
+export class UpdateSubmissionDto {
+    @ApiProperty({ example: { status: 'reviewed' }, description: 'Nuevos datos para la entrega' })
+    @IsObject()
+    @IsNotEmpty()
+    updateData: any;
+}

--- a/api-gateway/src/forms/forms.controller.ts
+++ b/api-gateway/src/forms/forms.controller.ts
@@ -2,9 +2,13 @@ import { Controller, Get, Post, Put, Delete, Body, Param, UseInterceptors, Uploa
 import { ClientProxy } from '@nestjs/microservices';
 import { Inject } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery, ApiBearerAuth, ApiConsumes } from '@nestjs/swagger';
 import { FormsService } from './forms.service';
 import { CreateFormDto } from './dto/create-form.dto';
+import { UpdateFormDto, SubmitFormDto, UpdateSubmissionDto } from './dto/forms.dto';
 
+@ApiTags('Forms')
+@ApiBearerAuth()
 @Controller('forms')
 export class FormsController {
   constructor(
@@ -13,170 +17,146 @@ export class FormsController {
   ) { }
 
   @Post()
+  @ApiOperation({ summary: 'Crear un nuevo formulario' })
+  @ApiResponse({ status: 201, description: 'Formulario creado exitosamente' })
   create(@Body() createFormDto: CreateFormDto) {
-    return this.client.send('create_form', createFormDto);
+    return this.client.send('create_form', createFormDto) ;
   }
 
   @Get()
+  @ApiOperation({ summary: 'Obtener todos los formularios' })
+  @ApiResponse({ status: 200, description: 'Lista de formularios' })
   findAll() {
     return this.client.send('find_all_forms', {});
   }
 
   @Get('submissions')
+  @ApiOperation({ summary: 'Obtener todas las respuestas de formularios' })
+  @ApiResponse({ status: 200, description: 'Lista de respuestas' })
   async findAllSubmissions() {
     try {
-      console.log('📝 [API Gateway] Fetching all submissions');
-      const result = await this.client.send('find_all_submissions', {}).toPromise();
-      console.log(`✅ [API Gateway] Received ${Array.isArray(result) ? result.length : 'invalid'} submissions`);
-      return result;
+      return await this.client.send('find_all_submissions', {}).toPromise();
     } catch (error) {
-      console.error('❌ [API Gateway] Error fetching submissions:', error);
-
       const status = error?.status || error?.statusCode || HttpStatus.INTERNAL_SERVER_ERROR;
-      const message = error?.message || 'Internal server error fetching submissions';
-
-      throw new HttpException({
-        status,
-        message,
-        timestamp: new Date().toISOString(),
-      }, status);
+      const message = error?.message || 'Error interno al obtener las respuestas';
+      throw new HttpException({ status, message, timestamp: new Date().toISOString() }, status);
     }
   }
 
   @Get('my-applications')
+  @ApiOperation({ summary: 'Obtener mis solicitudes (respuestas de formularios)' })
+  @ApiQuery({ name: 'userId', required: false })
+  @ApiQuery({ name: 'email', required: false })
+  @ApiQuery({ name: 'documentNumber', required: false })
+  @ApiResponse({ status: 200, description: 'Lista de solicitudes del usuario' })
   async findMyApplications(
     @Query('userId') userId?: string,
     @Query('email') email?: string,
     @Query('documentNumber') documentNumber?: string
   ) {
     try {
-      console.log('📝 [API Gateway] Fetching my applications for:', { userId, email, documentNumber });
       if (!userId && !email && !documentNumber) {
-        throw new HttpException('At least one of userId, email, or documentNumber is required', HttpStatus.BAD_REQUEST);
+        throw new HttpException('Se requiere al menos uno de los siguientes: userId, email o documentNumber', HttpStatus.BAD_REQUEST);
       }
-      const result = await this.client.send('find_submissions_by_user', { userId, email, documentNumber }).toPromise();
-      console.log(`✅ [API Gateway] Received ${Array.isArray(result) ? result.length : 'invalid'} applications for user`);
-      return result;
+      return await this.client.send('find_submissions_by_user', { userId, email, documentNumber }).toPromise();
     } catch (error) {
-      console.error('❌ [API Gateway] Error fetching user applications:', error);
       const status = error?.status || error?.statusCode || HttpStatus.INTERNAL_SERVER_ERROR;
-      const message = error?.message || 'Internal server error fetching user applications';
+      const message = error?.message || 'Error interno al obtener las solicitudes del usuario';
       throw new HttpException({ status, message }, status);
     }
   }
 
   @Delete('submissions/:id')
+  @ApiOperation({ summary: 'Eliminar una respuesta de formulario' })
+  @ApiParam({ name: 'id', description: 'ID de la respuesta' })
+  @ApiResponse({ status: 200, description: 'Respuesta eliminada' })
   async deleteSubmission(@Param('id') id: string) {
     try {
-      console.log('🗑️ [API Gateway] Deleting submission:', id);
-      const result = await this.client.send('delete_submission', { id }).toPromise();
-      console.log('✅ [API Gateway] Submission deleted');
-      return result;
+      return await this.client.send('delete_submission', { id }).toPromise();
     } catch (error) {
-      console.error('❌ [API Gateway] Error deleting submission:', error);
       const status = error?.status || error?.statusCode || HttpStatus.INTERNAL_SERVER_ERROR;
-      const message = error?.message || 'Internal server error deleting submission';
+      const message = error?.message || 'Error interno al eliminar la respuesta';
       throw new HttpException({ status, message }, status);
     }
   }
 
   @Put('submissions/:id')
-  async updateSubmission(@Param('id') id: string, @Body() updateData: any) {
+  @ApiOperation({ summary: 'Actualizar una respuesta de formulario' })
+  @ApiParam({ name: 'id', description: 'ID de la respuesta' })
+  @ApiResponse({ status: 200, description: 'Respuesta actualizada' })
+  async updateSubmission(@Param('id') id: string, @Body() dto: UpdateSubmissionDto) {
     try {
-      console.log('📝 [API Gateway] Updating submission:', id);
-      const result = await this.client.send('update_submission', { id, updateData }).toPromise();
-      console.log('✅ [API Gateway] Submission updated');
-      return result;
+      return await this.client.send('update_submission', { id, updateData: dto.updateData }).toPromise();
     } catch (error) {
-      console.error('❌ [API Gateway] Error updating submission:', error);
       const status = error?.status || error?.statusCode || HttpStatus.INTERNAL_SERVER_ERROR;
-      const message = error?.message || 'Internal server error updating submission';
+      const message = error?.message || 'Error interno al actualizar la respuesta';
       throw new HttpException({ status, message }, status);
     }
   }
 
   @Get(':id')
+  @ApiOperation({ summary: 'Obtener un formulario por ID' })
+  @ApiParam({ name: 'id', description: 'ID del formulario' })
+  @ApiResponse({ status: 200, description: 'Detalle del formulario' })
   findOne(@Param('id') id: string) {
     return this.client.send('find_one_form', { id });
   }
 
   @Put(':id')
-  update(@Param('id') id: string, @Body() updateFormDto: any) {
+  @ApiOperation({ summary: 'Actualizar un formulario' })
+  @ApiParam({ name: 'id', description: 'ID del formulario' })
+  @ApiResponse({ status: 200, description: 'Formulario actualizado' })
+  update(@Param('id') id: string, @Body() updateFormDto: UpdateFormDto) {
     return this.client.send('update_form', { id, updateData: updateFormDto });
   }
 
   @Delete(':id')
+  @ApiOperation({ summary: 'Eliminar un formulario' })
+  @ApiParam({ name: 'id', description: 'ID del formulario' })
+  @ApiResponse({ status: 200, description: 'Formulario eliminado' })
   remove(@Param('id') id: string) {
     return this.client.send('delete_form', { id });
   }
 
   @Get('type/:type')
+  @ApiOperation({ summary: 'Obtener un formulario por su código de tipo' })
+  @ApiParam({ name: 'type', description: 'Código del tipo (ej: voluntariado, interprete)' })
+  @ApiResponse({ status: 200, description: 'Formulario encontrado' })
   async findByType(@Param('type') type: string) {
     try {
-      console.log('📝 [API Gateway] Finding form by type:', type);
-      const result = await this.client.send('find_form_by_type', { type }).toPromise();
-      console.log('✅ [API Gateway] Form found:', result?.id);
-      return result;
+      return await this.client.send('find_form_by_type', { type }).toPromise();
     } catch (error: any) {
-      console.error('❌ [API Gateway] Error fetching form by type:', error);
-      console.error('❌ [API Gateway] Error details:', {
-        message: error?.message,
-        status: error?.status,
-        statusCode: error?.statusCode,
-      });
-
-      // Convert RpcException to HttpException
       const status = error?.status || error?.statusCode || HttpStatus.INTERNAL_SERVER_ERROR;
-      const message = error?.message || 'Internal server error';
-
+      const message = error?.message || 'Error interno al buscar el formulario';
       throw new HttpException(message, status);
     }
   }
 
   @Post('submit')
-  async submit(@Body() submissionDto: any) {
+  @ApiOperation({ summary: 'Enviar respuesta de un formulario' })
+  @ApiResponse({ status: 201, description: 'Respuesta enviada exitosamente' })
+  async submit(@Body() submissionDto: SubmitFormDto) {
     try {
-      console.log('📝 [API Gateway] Received form submission:', {
-        formId: submissionDto.formId,
-        submittedBy: submissionDto.submittedBy,
-        hasData: !!submissionDto.data,
-        dataSize: JSON.stringify(submissionDto.data || {}).length,
-      });
-
-      // Add timeout to prevent hanging
-      const result = await Promise.race([
+      return await Promise.race([
         this.client.send('submit_form', submissionDto).toPromise(),
         new Promise((_, reject) =>
-          setTimeout(() => reject(new Error('Request timeout after 30s')), 30000)
+          setTimeout(() => reject(new Error('Tiempo de espera agotado (30s)')), 30000)
         ),
       ]) as any;
-
-      console.log('✅ [API Gateway] Form submission successful:', {
-        submissionId: result?.submission?.id,
-        userStatus: result?.userStatus,
-      });
-
-      return result;
     } catch (error) {
-      console.error('❌ [API Gateway] Error in form submission:', error);
-      console.error('❌ [API Gateway] Error details:', {
-        message: error?.message,
-        name: error?.name,
-        stack: error?.stack,
-        code: error?.code,
-      });
       throw error;
     }
   }
 
   @Post('upload')
+  @ApiConsumes('multipart/form-data')
+  @ApiOperation({ summary: 'Subir un archivo adjunto para un formulario' })
   @UseInterceptors(FileInterceptor('file'))
   uploadFile(@UploadedFile() file: Express.Multer.File) {
     if (!file) {
-      throw new Error('No file uploaded');
+      throw new HttpException('No se subió ningún archivo', HttpStatus.BAD_REQUEST);
     }
 
-    // Convert file buffer to base64 for TCP transport
     const fileBase64 = file.buffer.toString('base64');
 
     return this.client.send('upload_file', {
@@ -185,5 +165,4 @@ export class FormsController {
       mimeType: file.mimetype,
     });
   }
-
 }

--- a/api-gateway/src/payments/dto/payments.dto.ts
+++ b/api-gateway/src/payments/dto/payments.dto.ts
@@ -1,0 +1,45 @@
+import { IsString, IsOptional, IsNumber, IsPositive } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+export class ChargeCardDto {
+    @ApiProperty({ example: 'tok_test_12345', description: 'Token de la tarjeta de crédito generado por Wompi' })
+    @IsString()
+    cardToken: string;
+
+    @ApiProperty({ example: 'uuid-user-123', description: 'ID del usuario que realiza el pago' })
+    @IsString()
+    userId: string;
+
+    @ApiProperty({ example: 'uuid-plan-456', description: 'ID del plan a activar' })
+    @IsString()
+    planId: string;
+
+    @ApiProperty({ example: 'mensual', enum: ['mensual', 'anual'], description: 'Ciclo de facturación' })
+    @IsString()
+    billingCycle: 'mensual' | 'anual';
+
+    @ApiPropertyOptional({ example: 'usuario@email.com', description: 'Correo electrónico del cliente' })
+    @IsString()
+    @IsOptional()
+    customerEmail?: string;
+}
+
+export class UpdatePaymentDto {
+    @ApiPropertyOptional({ example: 'APPROVED', description: 'Nuevo estado del pago', enum: ['PENDING', 'APPROVED', 'DECLINED', 'VOIDED', 'ERROR'] })
+    @IsString()
+    @IsOptional()
+    status?: string;
+
+    @ApiPropertyOptional({ example: 'txn_wompi_abc123', description: 'ID de transacción de Wompi' })
+    @IsString()
+    @IsOptional()
+    transactionId?: string;
+
+    @ApiPropertyOptional({ example: 150000, description: 'Monto del pago en centavos' })
+    @IsNumber()
+    @IsPositive()
+    @IsOptional()
+    @Type(() => Number)
+    amountCents?: number;
+}

--- a/api-gateway/src/payments/payments.controller.ts
+++ b/api-gateway/src/payments/payments.controller.ts
@@ -17,9 +17,10 @@ import {
 import { ClientProxy } from '@nestjs/microservices';
 import { Inject } from '@nestjs/common';
 import { firstValueFrom } from 'rxjs';
-import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiBody } from '@nestjs/swagger';
 import { PaymentsService } from './payments.service';
 import { InitiatePaymentDto } from './dto/create-payment.dto';
+import { ChargeCardDto, UpdatePaymentDto } from './dto/payments.dto';
 
 @ApiTags('Payments')
 @Controller('payments')
@@ -59,6 +60,7 @@ export class PaymentsController {
     @Post('webhook')
     @HttpCode(HttpStatus.OK)
     @ApiOperation({ summary: 'Wompi webhook endpoint' })
+    @ApiBody({ schema: { type: 'object', description: 'Evento enviado por Wompi. Estructura definida por Wompi.' } })
     @ApiResponse({ status: 200, description: 'Event processed successfully' })
     handleWebhook(
         @Body() event: any,
@@ -78,6 +80,7 @@ export class PaymentsController {
     @Post('webhooks/revenuecat')
     @HttpCode(HttpStatus.OK)
     @ApiOperation({ summary: 'RevenueCat webhook — handles Apple & Google IAP events' })
+    @ApiBody({ schema: { type: 'object', description: 'Evento enviado por RevenueCat. Estructura definida por RevenueCat.' } })
     @ApiResponse({ status: 200, description: 'Event received and processed' })
     handleRevenueCatWebhook(@Body() event: any) {
         this.logger.log(`📲 [RevenueCat] Incoming event: ${event?.event?.type} | User: ${event?.event?.app_user_id}`);
@@ -135,9 +138,9 @@ export class PaymentsController {
      * Procesa un cargo directo a tarjeta
      */
     @Post('charge-card')
-    @ApiOperation({ summary: 'Process direct card charge' })
-    @ApiResponse({ status: 201, description: 'Card charged successfully' })
-    chargeCard(@Body() chargeCardDto: any) {
+    @ApiOperation({ summary: 'Procesar cargo directo a tarjeta de crédito' })
+    @ApiResponse({ status: 201, description: 'Cargo procesado exitosamente' })
+    chargeCard(@Body() chargeCardDto: ChargeCardDto) {
         this.logger.log(`Processing card charge through gateway`);
         return this.client.send('payments.charge-card', chargeCardDto);
     }
@@ -179,9 +182,9 @@ export class PaymentsController {
      */
     @Put(':id')
     @ApiBearerAuth()
-    @ApiOperation({ summary: 'Update payment' })
-    @ApiResponse({ status: 200, description: 'Payment updated' })
-    update(@Param('id') id: string, @Body() updatePaymentDto: any) {
+    @ApiOperation({ summary: 'Actualizar estado o datos de un pago' })
+    @ApiResponse({ status: 200, description: 'Pago actualizado' })
+    update(@Param('id') id: string, @Body() updatePaymentDto: UpdatePaymentDto) {
         return this.client.send('payments.update', { id, updatePaymentDto });
     }
 

--- a/auth-ms/.dockerignore
+++ b/auth-ms/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.git
+.env

--- a/auth-ms/Dockerfile
+++ b/auth-ms/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:22-alpine
+WORKDIR /app
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/package.json ./
+CMD ["npm", "run", "start:prod"]

--- a/auth-ms/src/auth/auth.controller.ts
+++ b/auth-ms/src/auth/auth.controller.ts
@@ -56,6 +56,16 @@ export class AuthController {
     return this.authService.updatePushToken(data.userId, data.pushToken);
   }
 
+  @MessagePattern('update_voip_token')
+  updateVoipToken(@Payload() data: { userId: string; voipToken: string }): Promise<void> {
+    return this.authService.updateVoipToken(data.userId, data.voipToken);
+  }
+
+  @MessagePattern('update_fcm_token')
+  updateFcmToken(@Payload() data: { userId: string; fcmToken: string }): Promise<void> {
+    return this.authService.updateFcmToken(data.userId, data.fcmToken);
+  }
+
   @MessagePattern('reset_password')
   resetPassword(@Payload() data: ResetPasswordDto): Promise<any> {
     return this.authService.resetPassword(data);

--- a/auth-ms/src/auth/auth.service.ts
+++ b/auth-ms/src/auth/auth.service.ts
@@ -41,7 +41,15 @@ export class AuthService {
       });
 
       if (error) {
-        throw new UnauthorizedException(error.message);
+        const supabaseErrors: Record<string, string> = {
+          'Invalid login credentials': 'Correo electrónico o contraseña incorrectos.',
+          'Email not confirmed': 'Tu correo electrónico no ha sido verificado. Revisá tu bandeja de entrada.',
+          'User not found': 'No existe una cuenta con ese correo electrónico.',
+          'Too many requests': 'Demasiados intentos fallidos. Esperá unos minutos antes de intentar de nuevo.',
+          'Email rate limit exceeded': 'Demasiados intentos. Esperá unos minutos antes de intentar de nuevo.',
+        };
+        const localizedMessage = supabaseErrors[error.message] ?? 'Credenciales inválidas. Verificá tus datos e intentá de nuevo.';
+        throw new UnauthorizedException(localizedMessage);
       }
 
       const profile = await this.profileService.findById(authData.user.id);
@@ -68,6 +76,21 @@ export class AuthService {
     try {
       const supabase = this.supabaseService.getAdminClient();
 
+      // 0. Validar si el teléfono o documento ya existen antes de tocar Supabase Auth
+      if (phone) {
+        const existingPhone = await this.profileService.findByPhone(phone);
+        if (existingPhone) {
+          throw new ConflictException('El número ya se encuentra registrado');
+        }
+      }
+      
+      if (documentNumber) {
+        const docCheck = await this.checkDocumentExists(documentNumber);
+        if (docCheck.exists) {
+          throw new ConflictException('Este número de documento ya está registrado.');
+        }
+      }
+
       // 1. Create user in Supabase Auth
       const { data: authData, error: signUpError } = await supabase.auth.signUp({
         email,
@@ -91,25 +114,35 @@ export class AuthService {
         throw new BadRequestException('El registro de usuario falló.');
       }
 
-      // 2. Create profile in local database
-      const profile = await this.profileService.create({
-        id: authData.user.id,
-        firstName,
-        lastName,
-        documentTypeId,
-        documentNumber: documentNumber || '',
-        phone: phone || '',
-      });
+      try {
+        // 2. Create profile in local database
+        const profile = await this.profileService.create({
+          id: authData.user.id,
+          firstName,
+          lastName,
+          documentTypeId,
+          documentNumber: documentNumber || '',
+          phone: phone || '',
+        });
 
-      // 3. Generate JWT token
-      const token = this.tokenService.generateToken({ id: authData.user.id, email });
+        // 3. Generate JWT token
+        const token = this.tokenService.generateToken({ id: authData.user.id, email });
 
-      return {
-        user: this.profileService.toUserResponse(profile, authData.user),
-        token,
-        session: authData.session,
-        isProfileComplete: this.profileService.isProfileComplete(profile),
-      };
+        return {
+          user: this.profileService.toUserResponse(profile, authData.user),
+          token,
+          session: authData.session,
+          isProfileComplete: this.profileService.isProfileComplete(profile),
+        };
+      } catch (innerError) {
+        // ROLLBACK: Eliminar el usuario en Supabase Auth porque falló la creación del perfil
+        await supabase.auth.admin.deleteUser(authData.user.id);
+        
+        if (innerError.code === '23505' || (innerError.message && innerError.message.toLowerCase().includes('unique'))) {
+          throw new ConflictException('El número ya se encuentra registrado');
+        }
+        throw innerError;
+      }
     } catch (error) {
       if (error instanceof ConflictException || error instanceof BadRequestException) {
         throw error;
@@ -520,6 +553,58 @@ export class AuthService {
     } catch (error) {
       this.logger.error(`Error updating push token: ${error.message}`);
       throw new BadRequestException('Error al actualizar token de notificaciones');
+    }
+  }
+
+  async updateVoipToken(userId: string, voipToken: string): Promise<void> {
+    try {
+      const supabase = this.supabaseService.getAdminClient();
+      this.logger.log(`📞 Updating VoIP token for user ${userId}`);
+
+      if (voipToken) {
+        await supabase
+          .from('profiles')
+          .update({ voip_token: null })
+          .eq('voip_token', voipToken)
+          .neq('id', userId);
+      }
+
+      const { error } = await supabase
+        .from('profiles')
+        .update({ voip_token: voipToken || null })
+        .eq('id', userId);
+
+      if (error) throw new Error(error.message);
+      this.logger.log('✅ VoIP token updated successfully');
+    } catch (error) {
+      this.logger.error(`Error updating VoIP token: ${error.message}`);
+      throw new BadRequestException('Error al actualizar token de VoIP');
+    }
+  }
+
+  async updateFcmToken(userId: string, fcmToken: string): Promise<void> {
+    try {
+      const supabase = this.supabaseService.getAdminClient();
+      this.logger.log(`🤖 Updating FCM token for user ${userId}`);
+
+      if (fcmToken) {
+        await supabase
+          .from('profiles')
+          .update({ fcm_token: null })
+          .eq('fcm_token', fcmToken)
+          .neq('id', userId);
+      }
+
+      const { error } = await supabase
+        .from('profiles')
+        .update({ fcm_token: fcmToken || null })
+        .eq('id', userId);
+
+      if (error) throw new Error(error.message);
+      this.logger.log('✅ FCM token updated successfully');
+    } catch (error) {
+      this.logger.error(`Error updating FCM token: ${error.message}`);
+      throw new BadRequestException('Error al actualizar token de FCM');
     }
   }
 

--- a/auth-ms/src/auth/services/profile.service.ts
+++ b/auth-ms/src/auth/services/profile.service.ts
@@ -45,6 +45,12 @@ export class ProfileService {
         });
     }
 
+    async findByPhone(phone: string): Promise<Profile | null> {
+        return this.profileRepository.findOne({
+            where: { phone },
+        });
+    }
+
     async findByIdOrFail(id: string): Promise<Profile> {
         const profile = await this.findById(id);
         if (!profile) {

--- a/chat-ms/.dockerignore
+++ b/chat-ms/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.git
+.env

--- a/chat-ms/Dockerfile
+++ b/chat-ms/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:22-alpine
+WORKDIR /app
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/package.json ./
+CMD ["npm", "run", "start:prod"]

--- a/chat-ms/package.json
+++ b/chat-ms/package.json
@@ -30,10 +30,12 @@
         "@nestjs/microservices": "^11.1.5",
         "@nestjs/platform-express": "^11.0.1",
         "@supabase/supabase-js": "^2.84.0",
+        "apn": "^2.2.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "dotenv": "^17.2.0",
         "expo-server-sdk": "^4.0.0",
+        "firebase-admin": "^14.0.0",
         "livekit-server-sdk": "^2.15.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1"

--- a/chat-ms/src/chat/chat.service.ts
+++ b/chat-ms/src/chat/chat.service.ts
@@ -262,7 +262,7 @@ export class ChatService {
                 // Fetch push tokens for all recipients
                 const { data: recipientsProfiles } = await supabase
                     .from('profiles')
-                    .select('id, push_token')
+                    .select('id, push_token, voip_token, fcm_token')
                     .in('id', recipientIds);
 
                 // Send Notifications and Broadcasts (sin push para mensajes de sistema del grupo)
@@ -275,27 +275,40 @@ export class ChatService {
                         // Customize title: Group Name or Sender Name
                         const notifTitle = groupTitle ? `${groupTitle} (${senderName})` : senderName;
 
-                        await this.notificationsService.sendPushNotification(
-                            recipient.push_token,
-                            isCall ? `📞 Llamada de ${senderName}` : (notifTitle || 'Nuevo Mensaje'),
-                            isCall
-                                ? 'Toca para contestar...'
-                                : ((data.type === 'text' || isCallEnded) ? data.content : (data.type === 'image' ? '📷 Foto' : (data.type === 'audio' ? '🎤 Audio' : '📎 Archivo'))),
-                            {
-                                conversationId: data.conversationId,
-                                type: (isCall || isCallEnded || String(data.type) === 'call_rejected') ? data.type : 'new_message',
-                                senderId: data.senderId,
-                                senderName: senderName,
-                                roomName: isCall ? data.metadata?.roomName : undefined,
-                                isGroup: conversation.type === 'group' ? 'true' : 'false'
-                            },
-                            // Options — both call and call_ended use high-priority channel
-                            (isCall || isCallEnded || String(data.type) === 'call_rejected') ? {
-                                channelId: 'incoming_calls',
-                                priority: 'high',
-                                sound: isCall ? 'default' : undefined
-                            } : undefined
-                        );
+                        const payload = {
+                            conversationId: data.conversationId,
+                            type: (isCall || isCallEnded || String(data.type) === 'call_rejected') ? data.type : 'new_message',
+                            senderId: data.senderId,
+                            senderName: senderName,
+                            roomName: isCall ? data.metadata?.roomName : undefined,
+                            isGroup: conversation.type === 'group' ? 'true' : 'false'
+                        };
+
+                        if (isCall && (recipient.voip_token || recipient.fcm_token)) {
+                            // If it's a call and they have native call tokens
+                            if (recipient.voip_token) {
+                                await this.notificationsService.sendVoipPushNotification(recipient.voip_token, payload);
+                            }
+                            if (recipient.fcm_token) {
+                                await this.notificationsService.sendFcmDataNotification(recipient.fcm_token, payload);
+                            }
+                        } else if (recipient.push_token && !skipPushForSystem) {
+                            // Fallback to Expo Push Notification
+                            await this.notificationsService.sendPushNotification(
+                                recipient.push_token,
+                                isCall ? `📞 Llamada de ${senderName}` : (notifTitle || 'Nuevo Mensaje'),
+                                isCall
+                                    ? 'Toca para contestar...'
+                                    : ((data.type === 'text' || isCallEnded) ? data.content : (data.type === 'image' ? '📷 Foto' : (data.type === 'audio' ? '🎤 Audio' : '📎 Archivo'))),
+                                payload,
+                                // Options — both call and call_ended use high-priority channel
+                                (isCall || isCallEnded || String(data.type) === 'call_rejected') ? {
+                                    channelId: 'incoming_calls',
+                                    priority: 'high',
+                                    sound: isCall ? 'default' : undefined
+                                } : undefined
+                            );
+                        }
                     }
 
                     // 🚀 BROADCAST TO RECIPIENT'S USER CHANNEL
@@ -326,6 +339,20 @@ export class ChatService {
                             payload: {
                                 conversationId: data.conversationId,
                                 senderId: data.senderId,
+                            }
+                        });
+                    }
+
+                    if (data.type === 'call') {
+                        await recipientChannel.send({
+                            type: 'broadcast',
+                            event: 'incoming_call',
+                            payload: {
+                                conversationId: data.conversationId,
+                                senderId: data.senderId,
+                                senderName: senderName,
+                                roomName: data.metadata?.roomName,
+                                isGroup: conversation.type === 'group'
                             }
                         });
                     }

--- a/chat-ms/src/notifications/notifications.service.ts
+++ b/chat-ms/src/notifications/notifications.service.ts
@@ -1,13 +1,65 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Expo, ExpoPushMessage } from 'expo-server-sdk';
+import * as apn from 'apn';
+import { initializeApp, getApps, cert, applicationDefault } from 'firebase-admin/app';
+import { getMessaging, Message } from 'firebase-admin/messaging';
+import * as crypto from 'crypto';
 
 @Injectable()
 export class NotificationsService {
     private readonly logger = new Logger(NotificationsService.name);
     private expo: Expo;
+    private apnProvider: apn.Provider | null = null;
+    private fcmInitialized = false;
 
     constructor() {
         this.expo = new Expo();
+        this.initializeApn();
+        this.initializeFcm();
+    }
+
+    private initializeApn() {
+        try {
+            // Usually configured via env variables
+            if (process.env.APN_KEY_PATH || process.env.APN_KEY) {
+                const rawKey = process.env.APN_KEY ? process.env.APN_KEY.replace(/\\n/g, '\n') : '';
+                this.apnProvider = new apn.Provider({
+                    token: {
+                        key: rawKey || process.env.APN_KEY_PATH || '',
+                        keyId: process.env.APN_KEY_ID || '',
+                        teamId: process.env.APN_TEAM_ID || ''
+                    },
+                    production: process.env.NODE_ENV === 'production'
+                });
+                this.logger.log('🍏 APNs provider initialized for VoIP push');
+            } else {
+                this.logger.warn('🍏 APNs credentials not found. VoIP push will be simulated.');
+            }
+        } catch (error) {
+            this.logger.error(`Error initializing APNs: ${error.message}`);
+        }
+    }
+
+    private initializeFcm() {
+        try {
+            if (!getApps().length) {
+                if (process.env.GOOGLE_APPLICATION_CREDENTIALS || process.env.FIREBASE_PROJECT_ID) {
+                    initializeApp({
+                        credential: process.env.GOOGLE_APPLICATION_CREDENTIALS ? 
+                            cert(process.env.GOOGLE_APPLICATION_CREDENTIALS) : 
+                            applicationDefault()
+                    });
+                    this.fcmInitialized = true;
+                    this.logger.log('🤖 Firebase Admin initialized for FCM Data Push');
+                } else {
+                    this.logger.warn('🤖 Firebase credentials not found. FCM Data Push will be simulated.');
+                }
+            } else {
+                this.fcmInitialized = true;
+            }
+        } catch (error) {
+            this.logger.error(`Error initializing Firebase Admin: ${error.message}`);
+        }
     }
 
     /**
@@ -47,6 +99,72 @@ export class NotificationsService {
             }
         } catch (error) {
             this.logger.error('Error chunking notifications:', error);
+        }
+    }
+
+    /**
+     * Send native VoIP Push via APNs (Apple Push Notification service)
+     */
+    async sendVoipPushNotification(voipToken: string, payload: any) {
+        this.logger.log(`🍏 Sending VoIP Push to token: ${voipToken.substring(0, 10)}...`);
+        
+        if (!this.apnProvider) {
+            this.logger.warn('🍏 Simulated VoIP Push (No APN credentials configured)', payload);
+            return;
+        }
+
+        const notification = new apn.Notification();
+        // VoIP pushes do not require alert/sound. They wake the app up in the background.
+        notification.topic = `${process.env.BUNDLE_ID || 'com.tincadia.app'}.voip`;
+        notification.payload = {
+            callUUID: crypto.randomUUID(), // Unique UUID for CallKit
+            ...payload
+        };
+
+        try {
+            const result = await this.apnProvider.send(notification, voipToken);
+            if (result.failed.length > 0) {
+                this.logger.error(`🍏 VoIP Push failed:`, result.failed);
+            } else {
+                this.logger.log(`🍏 VoIP Push sent successfully.`);
+            }
+        } catch (error) {
+            this.logger.error(`🍏 Error sending VoIP Push: ${error.message}`);
+        }
+    }
+
+    /**
+     * Send Data-Only Message via Firebase Cloud Messaging for Android
+     */
+    async sendFcmDataNotification(fcmToken: string, payload: any) {
+        this.logger.log(`🤖 Sending FCM Data Message to token: ${fcmToken.substring(0, 10)}...`);
+        
+        if (!this.fcmInitialized) {
+            this.logger.warn('🤖 Simulated FCM Data Push (No Firebase credentials configured)', payload);
+            return;
+        }
+
+        const message: Message = {
+            token: fcmToken,
+            data: {
+                // FCM data payload requires all values to be strings
+                conversationId: String(payload.conversationId || ''),
+                type: String(payload.type || ''),
+                senderId: String(payload.senderId || ''),
+                senderName: String(payload.senderName || ''),
+                roomName: String(payload.roomName || ''),
+                isGroup: String(payload.isGroup || 'false')
+            },
+            android: {
+                priority: 'high' // Required for background wakeup
+            }
+        };
+
+        try {
+            const response = await getMessaging().send(message);
+            this.logger.log(`🤖 FCM Data Message sent successfully: ${response}`);
+        } catch (error) {
+            this.logger.error(`🤖 Error sending FCM Data Message: ${error.message}`);
         }
     }
 }

--- a/communication-ms/.dockerignore
+++ b/communication-ms/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.git
+.env

--- a/communication-ms/Dockerfile
+++ b/communication-ms/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:22-alpine
+WORKDIR /app
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/package.json ./
+CMD ["npm", "run", "start:prod"]

--- a/contacts-ms/.dockerignore
+++ b/contacts-ms/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.git
+.env

--- a/contacts-ms/Dockerfile
+++ b/contacts-ms/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:22-alpine
+WORKDIR /app
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/package.json ./
+CMD ["npm", "run", "start:prod"]

--- a/content-ms/.dockerignore
+++ b/content-ms/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.git
+.env

--- a/content-ms/Dockerfile
+++ b/content-ms/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:22-alpine
+WORKDIR /app
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/package.json ./
+CMD ["npm", "run", "start:prod"]

--- a/content-ms/src/app.module.ts
+++ b/content-ms/src/app.module.ts
@@ -22,11 +22,12 @@ import { LandingConfigModule } from './landing-config/landing-config.module';
           database: configService.get<string>('DB_NAME'),
           entities: [__dirname + '/**/*.entity{.ts,.js}'],
           synchronize: false, // Disabled - use SQL migrations in Supabase
-          ssl: configService.get<string>('DB_HOST')?.includes('railway') ||
+          ssl:
+            configService.get<string>('DB_HOST')?.includes('railway') ||
             configService.get<string>('DB_HOST')?.includes('supabase') ||
             configService.get<string>('DB_HOST')?.includes('supabase.co')
-            ? { rejectUnauthorized: false }
-            : false,
+              ? { rejectUnauthorized: false }
+              : false,
         };
       },
     }),
@@ -34,4 +35,4 @@ import { LandingConfigModule } from './landing-config/landing-config.module';
     LandingConfigModule,
   ],
 })
-export class AppModule { }
+export class AppModule {}

--- a/content-ms/src/content/cloudinary.service.ts
+++ b/content-ms/src/content/cloudinary.service.ts
@@ -4,142 +4,189 @@ import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class CloudinaryService {
-    constructor(private configService: ConfigService) {
-        // Helper to strip quotes if present (fixes Railway/production env issues)
-        const clean = (val: string | undefined) => val?.replace(/^"|"$/g, '').trim();
+  constructor(private configService: ConfigService) {
+    // Helper to strip quotes if present (fixes Railway/production env issues)
+    const clean = (val: string | undefined) =>
+      val?.replace(/^"|"$/g, '').trim();
 
-        cloudinary.config({
-            cloud_name: clean(this.configService.get<string>('CLOUDINARY_CLOUD_NAME')),
-            api_key: clean(this.configService.get<string>('CLOUDINARY_API_KEY')),
-            api_secret: clean(this.configService.get<string>('CLOUDINARY_API_SECRET')),
-        });
-    }
+    cloudinary.config({
+      cloud_name: clean(
+        this.configService.get<string>('CLOUDINARY_CLOUD_NAME'),
+      ),
+      api_key: clean(this.configService.get<string>('CLOUDINARY_API_KEY')),
+      api_secret: clean(
+        this.configService.get<string>('CLOUDINARY_API_SECRET'),
+      ),
+    });
+  }
 
-    // Upload video for lessons
-    async uploadVideo(buffer: Buffer, fileName: string, folder: string = 'tincadia/lessons'): Promise<UploadApiResponse> {
-        return new Promise((resolve, reject) => {
-            cloudinary.uploader.upload_stream(
-                {
-                    resource_type: 'video',
-                    folder: folder,
-                    public_id: `${Date.now()}_${fileName.replace(/\.[^/.]+$/, "")}`, // Remove extension for public_id
-                },
-                (error, result) => {
-                    if (error) reject(error);
-                    else resolve(result!);
-                },
-            ).end(buffer);
-        });
-    }
+  // Upload video for lessons
+  async uploadVideo(
+    buffer: Buffer,
+    fileName: string,
+    folder: string = 'tincadia/lessons',
+  ): Promise<UploadApiResponse> {
+    return new Promise((resolve, reject) => {
+      cloudinary.uploader
+        .upload_stream(
+          {
+            resource_type: 'video',
+            folder: folder,
+            public_id: `${Date.now()}_${fileName.replace(/\.[^/.]+$/, '')}`, // Remove extension for public_id
+          },
+          (error, result) => {
+            if (error) reject(error);
+            else resolve(result!);
+          },
+        )
+        .end(buffer);
+    });
+  }
 
-    // Upload image for thumbnails
-    async uploadImage(buffer: Buffer, fileName: string, folder: string = 'tincadia/thumbnails'): Promise<UploadApiResponse> {
-        return new Promise((resolve, reject) => {
-            cloudinary.uploader.upload_stream(
-                {
-                    resource_type: 'image',
-                    folder: folder,
-                    public_id: `${Date.now()}_${fileName.replace(/\.[^/.]+$/, "")}`,
-                    transformation: [{ width: 800, height: 450, crop: 'fill' }],
-                },
-                (error, result) => {
-                    if (error) reject(error);
-                    else resolve(result!);
-                },
-            ).end(buffer);
-        });
-    }
+  // Upload image for thumbnails
+  async uploadImage(
+    buffer: Buffer,
+    fileName: string,
+    folder: string = 'tincadia/thumbnails',
+  ): Promise<UploadApiResponse> {
+    return new Promise((resolve, reject) => {
+      cloudinary.uploader
+        .upload_stream(
+          {
+            resource_type: 'image',
+            folder: folder,
+            public_id: `${Date.now()}_${fileName.replace(/\.[^/.]+$/, '')}`,
+            transformation: [{ width: 800, height: 450, crop: 'fill' }],
+          },
+          (error, result) => {
+            if (error) reject(error);
+            else resolve(result!);
+          },
+        )
+        .end(buffer);
+    });
+  }
 
-    // Delete asset
-    async deleteAsset(publicId: string, resourceType: 'video' | 'image' | 'raw' = 'image'): Promise<void> {
-        await cloudinary.uploader.destroy(publicId, { resource_type: resourceType });
-    }
+  // Delete asset
+  async deleteAsset(
+    publicId: string,
+    resourceType: 'video' | 'image' | 'raw' = 'image',
+  ): Promise<void> {
+    await cloudinary.uploader.destroy(publicId, {
+      resource_type: resourceType,
+    });
+  }
 
-    /**
-     * Upload secure file (Image, Video, Audio) for Chat
-     * Access mode: authenticated (requires signed URL to view)
-     */
-    async uploadSecureFile(
-        buffer: Buffer,
-        fileName: string,
-        folder: string = 'tincadia/chat-media',
-        resourceType: 'image' | 'video' | 'raw' = 'image'
-    ): Promise<UploadApiResponse> {
-        return new Promise((resolve, reject) => {
-            cloudinary.uploader.upload_stream(
-                {
-                    resource_type: resourceType,
-                    folder: folder,
-                    public_id: `${Date.now()}_${fileName.replace(/\.[^/.]+$/, "")}`,
-                    type: 'authenticated', // Make it private!
-                    access_mode: 'authenticated',
-                },
-                (error, result) => {
-                    if (error) reject(error);
-                    else resolve(result!);
-                },
-            ).end(buffer);
-        });
-    }
-
-    /**
-     * Generate a signed URL for a private asset
-     * Valid for 1 hour (3600 seconds) by default
-     */
-    generateSignedUrl(publicId: string, resourceType: string = 'image', expirySeconds: number = 3600): string {
-        const url = cloudinary.url(publicId, {
+  /**
+   * Upload secure file (Image, Video, Audio) for Chat
+   * Access mode: authenticated (requires signed URL to view)
+   */
+  async uploadSecureFile(
+    buffer: Buffer,
+    fileName: string,
+    folder: string = 'tincadia/chat-media',
+    resourceType: 'image' | 'video' | 'raw' = 'image',
+  ): Promise<UploadApiResponse> {
+    return new Promise((resolve, reject) => {
+      cloudinary.uploader
+        .upload_stream(
+          {
             resource_type: resourceType,
-            type: 'authenticated',
-            sign_url: true,
-            secure: true,
-            expires_at: Math.floor(Date.now() / 1000) + expirySeconds,
-        });
-        return url;
-    }
+            folder: folder,
+            public_id: `${Date.now()}_${fileName.replace(/\.[^/.]+$/, '')}`,
+            type: 'authenticated', // Make it private!
+            access_mode: 'authenticated',
+          },
+          (error, result) => {
+            if (error) reject(error);
+            else resolve(result!);
+          },
+        )
+        .end(buffer);
+    });
+  }
 
-    /**
-     * Generate signature for client-side upload
-     */
-    getUploadSignature(params: Record<string, any>) {
-        // Use provided timestamp or generate new one
-        const timestamp = params.timestamp || Math.round((new Date).getTime() / 1000);
+  /**
+   * Generate a signed URL for a private asset
+   * Valid for 1 hour (3600 seconds) by default
+   */
+  generateSignedUrl(
+    publicId: string,
+    resourceType: string = 'image',
+    expirySeconds: number = 3600,
+  ): string {
+    const url = cloudinary.url(publicId, {
+      resource_type: resourceType,
+      type: 'authenticated',
+      sign_url: true,
+      secure: true,
+      expires_at: Math.floor(Date.now() / 1000) + expirySeconds,
+    });
+    return url;
+  }
 
-        // Ensure source is included if sent (Upload Widget sends source='uw')
-        const paramsToSign = { ...params, timestamp };
+  /**
+   * Generate signature for client-side upload
+   */
+  getUploadSignature(params: Record<string, any>) {
+    // Use provided timestamp or generate new one
+    const timestamp =
+      params.timestamp || Math.round(new Date().getTime() / 1000);
 
-        console.log('🔍 [Cloudinary Debug] Received Params:', JSON.stringify(params));
-        console.log('🔍 [Cloudinary Debug] Params to Sign:', JSON.stringify(paramsToSign));
+    // Ensure source is included if sent (Upload Widget sends source='uw')
+    const paramsToSign = { ...params, timestamp };
 
-        // Manual signature generation to ensure 'source' and other widget params are included
-        // 1. Sort keys
-        const sortedKeys = Object.keys(paramsToSign).sort();
+    console.log(
+      '🔍 [Cloudinary Debug] Received Params:',
+      JSON.stringify(params),
+    );
+    console.log(
+      '🔍 [Cloudinary Debug] Params to Sign:',
+      JSON.stringify(paramsToSign),
+    );
 
-        // 2. Create string "key=value&key2=value2"
-        const serializedParams = sortedKeys
-            .map(key => `${key}=${paramsToSign[key]}`)
-            .join('&');
+    // Manual signature generation to ensure 'source' and other widget params are included
+    // 1. Sort keys
+    const sortedKeys = Object.keys(paramsToSign).sort();
 
-        // 3. Append API Secret
-        const rawSecret = this.configService.get<string>('CLOUDINARY_API_SECRET');
-        const apiSecret = rawSecret?.replace(/^"|"$/g, '').trim();
-        const stringToSign = `${serializedParams}${apiSecret}`;
+    // 2. Create string "key=value&key2=value2"
+    const serializedParams = sortedKeys
+      .map((key) => `${key}=${paramsToSign[key]}`)
+      .join('&');
 
-        console.log('🔍 [Cloudinary Debug] Serialized Params:', serializedParams);
-        console.log('🔍 [Cloudinary Debug] String to Sign (masked secret):', `${serializedParams}[SECRET-LENGTH-${apiSecret?.length}]`);
+    // 3. Append API Secret
+    const rawSecret = this.configService.get<string>('CLOUDINARY_API_SECRET');
+    const apiSecret = rawSecret?.replace(/^"|"$/g, '').trim();
+    const stringToSign = `${serializedParams}${apiSecret}`;
 
-        // 4. SHA1 Hash (using cloudinary's crypto wrapper or native crypto if available)
-        // Since we imported 'cloudinary', we can use its util or node's crypto. 
-        // Let's use node's crypto for reliability.
-        const crypto = require('crypto');
-        const signature = crypto.createHash('sha1').update(stringToSign).digest('hex');
+    console.log('🔍 [Cloudinary Debug] Serialized Params:', serializedParams);
+    console.log(
+      '🔍 [Cloudinary Debug] String to Sign (masked secret):',
+      `${serializedParams}[SECRET-LENGTH-${apiSecret?.length}]`,
+    );
 
-        console.log('🔍 [Cloudinary Debug] Generated Signature:', signature);
+    // 4. SHA1 Hash (using cloudinary's crypto wrapper or native crypto if available)
+    // Since we imported 'cloudinary', we can use its util or node's crypto.
+    // Let's use node's crypto for reliability.
+    const crypto = require('crypto');
+    const signature = crypto
+      .createHash('sha1')
+      .update(stringToSign)
+      .digest('hex');
 
-        return {
-            signature,
-            timestamp,
-            cloudName: this.configService.get<string>('CLOUDINARY_CLOUD_NAME')?.replace(/^"|"$/g, '').trim(),
-            apiKey: this.configService.get<string>('CLOUDINARY_API_KEY')?.replace(/^"|"$/g, '').trim()
-        };
-    }
+    console.log('🔍 [Cloudinary Debug] Generated Signature:', signature);
+
+    return {
+      signature,
+      timestamp,
+      cloudName: this.configService
+        .get<string>('CLOUDINARY_CLOUD_NAME')
+        ?.replace(/^"|"$/g, '')
+        .trim(),
+      apiKey: this.configService
+        .get<string>('CLOUDINARY_API_KEY')
+        ?.replace(/^"|"$/g, '')
+        .trim(),
+    };
+  }
 }

--- a/content-ms/src/content/content.controller.ts
+++ b/content-ms/src/content/content.controller.ts
@@ -5,160 +5,192 @@ import { CloudinaryService } from './cloudinary.service';
 
 @Controller()
 export class ContentController {
-    constructor(
-        private readonly contentService: ContentService,
-        private readonly cloudinaryService: CloudinaryService
-    ) { }
+  constructor(
+    private readonly contentService: ContentService,
+    private readonly cloudinaryService: CloudinaryService,
+  ) {}
 
-    @MessagePattern('findAllCourses')
-    findAll(@Payload() data?: { after?: string }) {
-        return this.contentService.findAll(data?.after);
-    }
+  @MessagePattern('findAllCourses')
+  findAll(@Payload() data?: { after?: string }) {
+    return this.contentService.findAll(data?.after);
+  }
 
-    @MessagePattern('findAllCategories')
-    findAllCategories() {
-        return this.contentService.findAllCategories();
-    }
+  @MessagePattern('findAllCategories')
+  findAllCategories() {
+    return this.contentService.findAllCategories();
+  }
 
-    @MessagePattern('createCategory')
-    createCategory(@Payload() data: any) {
-        return this.contentService.createCategory(data);
-    }
+  @MessagePattern('createCategory')
+  createCategory(@Payload() data: any) {
+    return this.contentService.createCategory(data);
+  }
 
-    @MessagePattern('createCourse')
-    create(@Payload() data: any) {
-        return this.contentService.create(data);
-    }
+  @MessagePattern('createCourse')
+  create(@Payload() data: any) {
+    return this.contentService.create(data);
+  }
 
-    @MessagePattern('updateCourse')
-    update(@Payload() data: { id: string; updateData: any }) {
-        return this.contentService.update(data.id, data.updateData);
-    }
+  @MessagePattern('updateCourse')
+  update(@Payload() data: { id: string; updateData: any }) {
+    return this.contentService.update(data.id, data.updateData);
+  }
 
-    @MessagePattern('findOneCourse')
-    findOne(@Payload() data: any) {
-        // Accept legacy payload as string id or object { id, hasAccess }
-        const id = typeof data === 'string' ? data : data?.id;
-        const hasAccess = typeof data === 'object' ? !!data?.hasAccess : false;
-        return this.contentService.findOneWithAccess(id, hasAccess);
-    }
+  @MessagePattern('findOneCourse')
+  findOne(@Payload() data: any) {
+    // Accept legacy payload as string id or object { id, hasAccess }
+    const id = typeof data === 'string' ? data : data?.id;
+    const hasAccess = typeof data === 'object' ? !!data?.hasAccess : false;
+    return this.contentService.findOneWithAccess(id, hasAccess);
+  }
 
-    @MessagePattern('createModule')
-    createModule(@Payload() data: any) {
-        return this.contentService.createModule(data);
-    }
+  @MessagePattern('createModule')
+  createModule(@Payload() data: any) {
+    return this.contentService.createModule(data);
+  }
 
-    @MessagePattern('createLesson')
-    createLesson(@Payload() data: any) {
-        return this.contentService.createLesson(data);
-    }
+  @MessagePattern('createLesson')
+  createLesson(@Payload() data: any) {
+    return this.contentService.createLesson(data);
+  }
 
-    @MessagePattern('uploadLessonVideo')
-    async uploadVideo(@Payload() data: { buffer: number[]; fileName: string; lessonId: string }) {
-        const buffer = Buffer.from(data.buffer);
+  @MessagePattern('uploadLessonVideo')
+  async uploadVideo(
+    @Payload() data: { buffer: number[]; fileName: string; lessonId: string },
+  ) {
+    const buffer = Buffer.from(data.buffer);
 
-        // Fetch hierarchy for folder structure
-        const hierarchy = await this.contentService.getLessonHierarchy(data.lessonId);
-        const folderPath = hierarchy
-            ? `Tincadia/${this.sanitize(hierarchy.categoryName)}/${this.sanitize(hierarchy.courseTitle)}/${this.sanitize(hierarchy.moduleTitle)}`
-            : 'Tincadia/Uncategorized';
+    // Fetch hierarchy for folder structure
+    const hierarchy = await this.contentService.getLessonHierarchy(
+      data.lessonId,
+    );
+    const folderPath = hierarchy
+      ? `Tincadia/${this.sanitize(hierarchy.categoryName)}/${this.sanitize(hierarchy.courseTitle)}/${this.sanitize(hierarchy.moduleTitle)}`
+      : 'Tincadia/Uncategorized';
 
-        const result = await this.cloudinaryService.uploadVideo(buffer, data.fileName, folderPath);
-        const duration = Math.round(result.duration);
-        await this.contentService.updateLessonVideo(data.lessonId, result.secure_url, duration);
-        return { url: result.secure_url, duration };
-    }
+    const result = await this.cloudinaryService.uploadVideo(
+      buffer,
+      data.fileName,
+      folderPath,
+    );
+    const duration = Math.round(result.duration);
+    await this.contentService.updateLessonVideo(
+      data.lessonId,
+      result.secure_url,
+      duration,
+    );
+    return { url: result.secure_url, duration };
+  }
 
-    @MessagePattern('uploadCourseThumbnail')
-    async uploadThumbnail(@Payload() data: { buffer: number[]; fileName: string; courseId: string }) {
-        const buffer = Buffer.from(data.buffer);
+  @MessagePattern('uploadCourseThumbnail')
+  async uploadThumbnail(
+    @Payload() data: { buffer: number[]; fileName: string; courseId: string },
+  ) {
+    const buffer = Buffer.from(data.buffer);
 
-        // Fetch hierarchy for folder structure
-        const hierarchy = await this.contentService.getCourseHierarchy(data.courseId);
-        const folderPath = hierarchy
-            ? `Tincadia/${this.sanitize(hierarchy.categoryName)}/${this.sanitize(hierarchy.courseTitle)}/thumbnail`
-            : 'Tincadia/Uncategorized/thumbnail';
+    // Fetch hierarchy for folder structure
+    const hierarchy = await this.contentService.getCourseHierarchy(
+      data.courseId,
+    );
+    const folderPath = hierarchy
+      ? `Tincadia/${this.sanitize(hierarchy.categoryName)}/${this.sanitize(hierarchy.courseTitle)}/thumbnail`
+      : 'Tincadia/Uncategorized/thumbnail';
 
-        const result = await this.cloudinaryService.uploadImage(buffer, data.fileName, folderPath);
-        await this.contentService.updateCourseThumbnail(data.courseId, result.secure_url);
-        return { url: result.secure_url };
-    }
+    const result = await this.cloudinaryService.uploadImage(
+      buffer,
+      data.fileName,
+      folderPath,
+    );
+    await this.contentService.updateCourseThumbnail(
+      data.courseId,
+      result.secure_url,
+    );
+    return { url: result.secure_url };
+  }
 
-    private sanitize(str: string): string {
-        return str.replace(/[^a-z0-9]/gi, '_').toLowerCase();
-    }
+  private sanitize(str: string): string {
+    return str.replace(/[^a-z0-9]/gi, '_').toLowerCase();
+  }
 
-    @MessagePattern('deleteCourse')
-    deleteCourse(@Payload() id: string) {
-        return this.contentService.deleteCourse(id);
-    }
+  @MessagePattern('deleteCourse')
+  deleteCourse(@Payload() id: string) {
+    return this.contentService.deleteCourse(id);
+  }
 
-    @MessagePattern('updateCategory')
-    updateCategory(@Payload() data: { id: string; updateData: any }) {
-        return this.contentService.updateCategory(data.id, data.updateData);
-    }
+  @MessagePattern('updateCategory')
+  updateCategory(@Payload() data: { id: string; updateData: any }) {
+    return this.contentService.updateCategory(data.id, data.updateData);
+  }
 
-    @MessagePattern('deleteCategory')
-    deleteCategory(@Payload() id: string) {
-        return this.contentService.deleteCategory(id);
-    }
+  @MessagePattern('deleteCategory')
+  deleteCategory(@Payload() id: string) {
+    return this.contentService.deleteCategory(id);
+  }
 
-    @MessagePattern('updateModule')
-    updateModule(@Payload() data: { id: string; updateData: any }) {
-        return this.contentService.updateModule(data.id, data.updateData);
-    }
+  @MessagePattern('updateModule')
+  updateModule(@Payload() data: { id: string; updateData: any }) {
+    return this.contentService.updateModule(data.id, data.updateData);
+  }
 
-    @MessagePattern('deleteModule')
-    deleteModule(@Payload() id: string) {
-        return this.contentService.deleteModule(id);
-    }
+  @MessagePattern('deleteModule')
+  deleteModule(@Payload() id: string) {
+    return this.contentService.deleteModule(id);
+  }
 
-    @MessagePattern('updateLesson')
-    updateLesson(@Payload() data: { id: string; updateData: any }) {
-        return this.contentService.updateLesson(data.id, data.updateData);
-    }
+  @MessagePattern('updateLesson')
+  updateLesson(@Payload() data: { id: string; updateData: any }) {
+    return this.contentService.updateLesson(data.id, data.updateData);
+  }
 
-    @MessagePattern('deleteLesson')
-    deleteLesson(@Payload() id: string) {
-        return this.contentService.deleteLesson(id);
-    }
+  @MessagePattern('deleteLesson')
+  deleteLesson(@Payload() id: string) {
+    return this.contentService.deleteLesson(id);
+  }
 
-    @MessagePattern('uploadChatMedia')
-    async uploadChatMedia(@Payload() data: { buffer: number[]; fileName: string; type: 'image' | 'video' | 'raw' }) {
-        const buffer = Buffer.from(data.buffer);
+  @MessagePattern('uploadChatMedia')
+  async uploadChatMedia(
+    @Payload()
+    data: {
+      buffer: number[];
+      fileName: string;
+      type: 'image' | 'video' | 'raw';
+    },
+  ) {
+    const buffer = Buffer.from(data.buffer);
 
-        // Define subfolder based on type
-        let folder = 'tincadia/chat-media';
-        if (data.type === 'video') folder += '/videos';
-        else if (data.type === 'raw') folder += '/audio';
-        else folder += '/images';
+    // Define subfolder based on type
+    let folder = 'tincadia/chat-media';
+    if (data.type === 'video') folder += '/videos';
+    else if (data.type === 'raw') folder += '/audio';
+    else folder += '/images';
 
-        const result = await this.cloudinaryService.uploadSecureFile(
-            buffer,
-            data.fileName,
-            folder,
-            data.type
-        );
-        return {
-            public_id: result.public_id,
-            url: result.secure_url,
-            format: result.format,
-            resource_type: result.resource_type
-        };
-    }
+    const result = await this.cloudinaryService.uploadSecureFile(
+      buffer,
+      data.fileName,
+      folder,
+      data.type,
+    );
+    return {
+      public_id: result.public_id,
+      url: result.secure_url,
+      format: result.format,
+      resource_type: result.resource_type,
+    };
+  }
 
-    @MessagePattern('generateSignedUrl')
-    generateSignedUrl(@Payload() data: { publicId: string; resourceType?: string }) {
-        return {
-            url: this.cloudinaryService.generateSignedUrl(
-                data.publicId,
-                data.resourceType || 'image'
-            )
-        };
-    }
+  @MessagePattern('generateSignedUrl')
+  generateSignedUrl(
+    @Payload() data: { publicId: string; resourceType?: string },
+  ) {
+    return {
+      url: this.cloudinaryService.generateSignedUrl(
+        data.publicId,
+        data.resourceType || 'image',
+      ),
+    };
+  }
 
-    @MessagePattern('getUploadSignature')
-    getUploadSignature(@Payload() params: Record<string, any>) {
-        return this.cloudinaryService.getUploadSignature(params);
-    }
+  @MessagePattern('getUploadSignature')
+  getUploadSignature(@Payload() params: Record<string, any>) {
+    return this.cloudinaryService.getUploadSignature(params);
+  }
 }

--- a/content-ms/src/content/content.module.ts
+++ b/content-ms/src/content/content.module.ts
@@ -13,11 +13,17 @@ import { PricingService } from './pricing.service';
 import { PricingPlan } from './entities/pricing-plan.entity';
 
 @Module({
-    imports: [
-        ConfigModule.forRoot(),
-        TypeOrmModule.forFeature([Course, Category, CourseModule, Lesson, PricingPlan])
-    ],
-    controllers: [ContentController, PricingController],
-    providers: [ContentService, CloudinaryService, PricingService],
+  imports: [
+    ConfigModule.forRoot(),
+    TypeOrmModule.forFeature([
+      Course,
+      Category,
+      CourseModule,
+      Lesson,
+      PricingPlan,
+    ]),
+  ],
+  controllers: [ContentController, PricingController],
+  providers: [ContentService, CloudinaryService, PricingService],
 })
-export class ContentModule { }
+export class ContentModule {}

--- a/content-ms/src/content/content.service.ts
+++ b/content-ms/src/content/content.service.ts
@@ -8,208 +8,224 @@ import { Module } from './entities/module.entity';
 
 @Injectable()
 export class ContentService {
-    constructor(
-        @InjectRepository(Course)
-        private courseRepository: Repository<Course>,
-        @InjectRepository(Category)
-        private categoryRepository: Repository<Category>,
-        @InjectRepository(Module)
-        private moduleRepository: Repository<Module>,
-        @InjectRepository(Lesson)
-        private lessonRepository: Repository<Lesson>,
-    ) { }
+  constructor(
+    @InjectRepository(Course)
+    private courseRepository: Repository<Course>,
+    @InjectRepository(Category)
+    private categoryRepository: Repository<Category>,
+    @InjectRepository(Module)
+    private moduleRepository: Repository<Module>,
+    @InjectRepository(Lesson)
+    private lessonRepository: Repository<Lesson>,
+  ) {}
 
-    async findAll(after?: string) {
-        if (after) {
-            return this.courseRepository.find({
-                where: { updatedAt: MoreThan(new Date(after)) },
-                relations: ['category', 'modules']
-            });
-        }
-        return this.courseRepository.find({ relations: ['category', 'modules'] });
+  async findAll(after?: string) {
+    if (after) {
+      return this.courseRepository.find({
+        where: { updatedAt: MoreThan(new Date(after)) },
+        relations: ['category', 'modules'],
+      });
+    }
+    return this.courseRepository.find({ relations: ['category', 'modules'] });
+  }
+
+  async findAllCategories() {
+    return this.categoryRepository.find();
+  }
+
+  async createCategory(data: { name: string; description?: string }) {
+    const category = this.categoryRepository.create(data);
+    return this.categoryRepository.save(category);
+  }
+
+  async create(data: any) {
+    const course = this.courseRepository.create(data);
+    return this.courseRepository.save(course);
+  }
+
+  async update(id: string, data: any) {
+    await this.courseRepository.update(id, data);
+    return this.findOne(id);
+  }
+
+  async findOneWithAccess(id: string, hasAccess: boolean) {
+    return this.findOne(id, { hasAccess });
+  }
+
+  async findOne(
+    id: string,
+    opts?: { includePaid?: boolean; hasAccess?: boolean },
+  ) {
+    const course = await this.courseRepository.findOne({
+      where: { id },
+      relations: ['category', 'modules', 'modules.lessons'],
+      order: {
+        modules: {
+          order: 'ASC',
+          lessons: {
+            order: 'ASC',
+          },
+        },
+      },
+    });
+
+    if (!course) return null;
+
+    // If includePaid/hasAccess true, return without masking
+    if (opts?.includePaid || opts?.hasAccess) {
+      return course;
     }
 
-    async findAllCategories() {
-        return this.categoryRepository.find();
-    }
+    return this.maskPaidContent(course, !!opts?.hasAccess);
+  }
 
-    async createCategory(data: { name: string; description?: string }) {
-        const category = this.categoryRepository.create(data);
-        return this.categoryRepository.save(category);
-    }
+  async createModule(data: any) {
+    const module = this.moduleRepository.create(data);
+    return this.moduleRepository.save(module);
+  }
 
-    async create(data: any) {
-        const course = this.courseRepository.create(data);
-        return this.courseRepository.save(course);
-    }
+  async createLesson(data: any) {
+    const lesson = this.lessonRepository.create(data);
+    return this.lessonRepository.save(lesson);
+  }
 
-    async update(id: string, data: any) {
-        await this.courseRepository.update(id, data);
-        return this.findOne(id);
+  async updateLessonVideo(
+    lessonId: string,
+    videoUrl: string,
+    durationSeconds?: number,
+  ) {
+    const lesson = await this.lessonRepository.findOneBy({ id: lessonId });
+    if (lesson) {
+      lesson.videoUrl = videoUrl;
+      if (durationSeconds) lesson.durationSeconds = durationSeconds;
+      return this.lessonRepository.save(lesson);
     }
+    return null;
+  }
 
-    async findOneWithAccess(id: string, hasAccess: boolean) {
-        return this.findOne(id, { hasAccess });
-    }
+  async updateCourseThumbnail(courseId: string, thumbnailUrl: string) {
+    return this.courseRepository.update(courseId, { thumbnailUrl });
+  }
 
-    async findOne(id: string, opts?: { includePaid?: boolean; hasAccess?: boolean }) {
-        const course = await this.courseRepository.findOne({
-            where: { id },
-            relations: ['category', 'modules', 'modules.lessons'],
-            order: {
-                modules: {
-                    order: 'ASC',
-                    lessons: {
-                        order: 'ASC'
-                    }
-                }
-            }
+  async deleteCourse(id: string) {
+    return this.courseRepository.delete(id);
+  }
+
+  // --- Category CRUD ---
+  async updateCategory(id: string, data: any) {
+    await this.categoryRepository.update(id, data);
+    return this.categoryRepository.findOneBy({ id });
+  }
+
+  async deleteCategory(id: string) {
+    return this.categoryRepository.delete(id);
+  }
+
+  // --- Module CRUD ---
+  async updateModule(id: string, data: any) {
+    await this.moduleRepository.update(id, data);
+    return this.moduleRepository.findOneBy({ id });
+  }
+
+  async deleteModule(id: string) {
+    return this.moduleRepository.delete(id);
+  }
+
+  // --- Lesson CRUD ---
+  async updateLesson(id: string, data: any) {
+    await this.lessonRepository.update(id, data);
+    return this.lessonRepository.findOneBy({ id });
+  }
+
+  async deleteLesson(id: string) {
+    return this.lessonRepository.delete(id);
+  }
+
+  // --- Helpers for Cloudinary Hierarchy ---
+
+  private maskPaidContent(course: Course, hasAccess: boolean) {
+    if (hasAccess) return course;
+
+    const accessScope = (course as any).accessScope || 'course';
+    const courseIsPaid = (course as any).isPaid || false;
+    const previewLimit =
+      typeof (course as any).previewLimit === 'number'
+        ? (course as any).previewLimit
+        : 0;
+    let previewsRemaining = previewLimit;
+
+    const sortByOrder = <T extends { order?: number }>(arr: T[] = []) =>
+      [...arr].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+
+    const maskedCourse = {
+      ...course,
+      modules: sortByOrder(course.modules || []).map((m: any) => {
+        const moduleIsPaid = !!m.isPaid;
+        const lessons = sortByOrder(m.lessons || []).map((l: any) => {
+          const lessonIsPaid = !!l.isPaid;
+          let isPreview = !!l.isFreePreview;
+
+          // Assign preview slots for course-level paywall if not already preview
+          if (
+            !isPreview &&
+            accessScope === 'course' &&
+            courseIsPaid &&
+            previewsRemaining > 0
+          ) {
+            isPreview = true;
+            previewsRemaining -= 1;
+          }
+
+          let locked = false;
+          if (accessScope === 'course' && courseIsPaid) {
+            locked = !isPreview;
+          } else if (accessScope === 'module' && moduleIsPaid) {
+            locked = !isPreview;
+          } else if (accessScope === 'lesson' && lessonIsPaid) {
+            locked = !isPreview;
+          }
+
+          return {
+            ...l,
+            isFreePreview: isPreview,
+            videoUrl: locked ? null : l.videoUrl,
+            locked,
+          };
         });
+        return { ...m, lessons };
+      }),
+    };
 
-        if (!course) return null;
+    return maskedCourse;
+  }
 
-        // If includePaid/hasAccess true, return without masking
-        if (opts?.includePaid || opts?.hasAccess) {
-            return course;
-        }
+  async getLessonHierarchy(lessonId: string) {
+    const lesson = await this.lessonRepository.findOne({
+      where: { id: lessonId },
+      relations: ['module', 'module.course', 'module.course.category'],
+    });
 
-        return this.maskPaidContent(course, !!opts?.hasAccess);
-    }
+    if (!lesson) return null;
 
-    async createModule(data: any) {
-        const module = this.moduleRepository.create(data);
-        return this.moduleRepository.save(module);
-    }
+    const categoryName =
+      lesson.module?.course?.category?.name || 'Uncategorized';
+    const courseTitle = lesson.module?.course?.title || 'Unknown Course';
+    const moduleTitle = lesson.module?.title || 'Unknown Module';
 
-    async createLesson(data: any) {
-        const lesson = this.lessonRepository.create(data);
-        return this.lessonRepository.save(lesson);
-    }
+    return { categoryName, courseTitle, moduleTitle };
+  }
 
-    async updateLessonVideo(lessonId: string, videoUrl: string, durationSeconds?: number) {
-        const lesson = await this.lessonRepository.findOneBy({ id: lessonId });
-        if (lesson) {
-            lesson.videoUrl = videoUrl;
-            if (durationSeconds) lesson.durationSeconds = durationSeconds;
-            return this.lessonRepository.save(lesson);
-        }
-        return null;
-    }
+  async getCourseHierarchy(courseId: string) {
+    const course = await this.courseRepository.findOne({
+      where: { id: courseId },
+      relations: ['category'],
+    });
 
-    async updateCourseThumbnail(courseId: string, thumbnailUrl: string) {
-        return this.courseRepository.update(courseId, { thumbnailUrl });
-    }
+    if (!course) return null;
 
-    async deleteCourse(id: string) {
-        return this.courseRepository.delete(id);
-    }
+    const categoryName = course.category?.name || 'Uncategorized';
+    const courseTitle = course.title || 'Unknown Course';
 
-    // --- Category CRUD ---
-    async updateCategory(id: string, data: any) {
-        await this.categoryRepository.update(id, data);
-        return this.categoryRepository.findOneBy({ id });
-    }
-
-    async deleteCategory(id: string) {
-        return this.categoryRepository.delete(id);
-    }
-
-    // --- Module CRUD ---
-    async updateModule(id: string, data: any) {
-        await this.moduleRepository.update(id, data);
-        return this.moduleRepository.findOneBy({ id });
-    }
-
-    async deleteModule(id: string) {
-        return this.moduleRepository.delete(id);
-    }
-
-    // --- Lesson CRUD ---
-    async updateLesson(id: string, data: any) {
-        await this.lessonRepository.update(id, data);
-        return this.lessonRepository.findOneBy({ id });
-    }
-
-    async deleteLesson(id: string) {
-        return this.lessonRepository.delete(id);
-    }
-
-    // --- Helpers for Cloudinary Hierarchy ---
-
-    private maskPaidContent(course: Course, hasAccess: boolean) {
-        if (hasAccess) return course;
-
-        const accessScope = (course as any).accessScope || 'course';
-        const courseIsPaid = (course as any).isPaid || false;
-        const previewLimit = typeof (course as any).previewLimit === 'number' ? (course as any).previewLimit : 0;
-        let previewsRemaining = previewLimit;
-
-        const sortByOrder = <T extends { order?: number }>(arr: T[] = []) =>
-            [...arr].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
-
-        const maskedCourse = {
-            ...course,
-            modules: sortByOrder(course.modules || []).map((m: any) => {
-                const moduleIsPaid = !!m.isPaid;
-                const lessons = sortByOrder(m.lessons || []).map((l: any) => {
-                    const lessonIsPaid = !!l.isPaid;
-                    let isPreview = !!l.isFreePreview;
-
-                    // Assign preview slots for course-level paywall if not already preview
-                    if (!isPreview && accessScope === 'course' && courseIsPaid && previewsRemaining > 0) {
-                        isPreview = true;
-                        previewsRemaining -= 1;
-                    }
-
-                    let locked = false;
-                    if (accessScope === 'course' && courseIsPaid) {
-                        locked = !isPreview;
-                    } else if (accessScope === 'module' && moduleIsPaid) {
-                        locked = !isPreview;
-                    } else if (accessScope === 'lesson' && lessonIsPaid) {
-                        locked = !isPreview;
-                    }
-
-                    return {
-                        ...l,
-                        isFreePreview: isPreview,
-                        videoUrl: locked ? null : l.videoUrl,
-                        locked,
-                    };
-                });
-                return { ...m, lessons };
-            }),
-        };
-
-        return maskedCourse;
-    }
-
-    async getLessonHierarchy(lessonId: string) {
-        const lesson = await this.lessonRepository.findOne({
-            where: { id: lessonId },
-            relations: ['module', 'module.course', 'module.course.category'],
-        });
-
-        if (!lesson) return null;
-
-        const categoryName = lesson.module?.course?.category?.name || 'Uncategorized';
-        const courseTitle = lesson.module?.course?.title || 'Unknown Course';
-        const moduleTitle = lesson.module?.title || 'Unknown Module';
-
-        return { categoryName, courseTitle, moduleTitle };
-    }
-
-    async getCourseHierarchy(courseId: string) {
-        const course = await this.courseRepository.findOne({
-            where: { id: courseId },
-            relations: ['category'],
-        });
-
-        if (!course) return null;
-
-        const categoryName = course.category?.name || 'Uncategorized';
-        const courseTitle = course.title || 'Unknown Course';
-
-        return { categoryName, courseTitle };
-    }
+    return { categoryName, courseTitle };
+  }
 }

--- a/content-ms/src/content/dto/create-course.dto.ts
+++ b/content-ms/src/content/dto/create-course.dto.ts
@@ -1,13 +1,13 @@
 export class CreateCourseDto {
-    title: string;
-    description: string;
-    thumbnailUrl?: string; // Optional initially
-    categoryId: string;
-    accessScope?: 'course' | 'module' | 'lesson';
-    isPaid?: boolean;
-    previewLimit?: number | null;
-    priceInCents?: number;
-    priceLabel?: string;
-    learningPoints?: string[];
-    features?: string[];
+  title: string;
+  description: string;
+  thumbnailUrl?: string; // Optional initially
+  categoryId: string;
+  accessScope?: 'course' | 'module' | 'lesson';
+  isPaid?: boolean;
+  previewLimit?: number | null;
+  priceInCents?: number;
+  priceLabel?: string;
+  learningPoints?: string[];
+  features?: string[];
 }

--- a/content-ms/src/content/entities/category.entity.ts
+++ b/content-ms/src/content/entities/category.entity.ts
@@ -1,23 +1,30 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToMany, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  OneToMany,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 import { Course } from './course.entity';
 
 @Entity('categories')
 export class Category {
-    @PrimaryGeneratedColumn('uuid')
-    id: string;
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
 
-    @Column()
-    name: string;
+  @Column()
+  name: string;
 
-    @Column({ nullable: true })
-    description: string;
+  @Column({ nullable: true })
+  description: string;
 
-    @OneToMany(() => Course, (course) => course.category)
-    courses: Course[];
+  @OneToMany(() => Course, (course) => course.category)
+  courses: Course[];
 
-    @CreateDateColumn({ name: 'created_at' })
-    createdAt: Date;
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
 
-    @UpdateDateColumn({ name: 'updated_at' })
-    updatedAt: Date;
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
 }

--- a/content-ms/src/content/entities/course.entity.ts
+++ b/content-ms/src/content/entities/course.entity.ts
@@ -1,69 +1,89 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany, JoinColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  OneToMany,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 import { Category } from './category.entity';
 import { Module } from './module.entity';
 
 @Entity('courses')
 export class Course {
-    @PrimaryGeneratedColumn('uuid')
-    id: string;
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
 
-    @Column()
-    title: string;
+  @Column()
+  title: string;
 
-    @Column({ type: 'text', nullable: true })
-    description: string;
+  @Column({ type: 'text', nullable: true })
+  description: string;
 
-    @Column({ nullable: true })
-    thumbnailUrl: string;
+  @Column({ nullable: true })
+  thumbnailUrl: string;
 
-    @ManyToOne(() => Category, (category) => category.courses, { onDelete: 'SET NULL' })
-    @JoinColumn({ name: 'category_id' })
-    category: Category;
+  @ManyToOne(() => Category, (category) => category.courses, {
+    onDelete: 'SET NULL',
+  })
+  @JoinColumn({ name: 'category_id' })
+  category: Category;
 
-    @Column({ name: 'category_id', type: 'uuid' })
-    categoryId: string;
+  @Column({ name: 'category_id', type: 'uuid' })
+  categoryId: string;
 
-    @OneToMany(() => Module, (module) => module.course)
-    modules: Module[];
+  @OneToMany(() => Module, (module) => module.course)
+  modules: Module[];
 
-    @Column({ default: false })
-    isPublished: boolean;
+  @Column({ default: false })
+  isPublished: boolean;
 
-    @Column({
-        name: 'access_scope',
-        type: 'varchar',
-        length: 20,
-        default: 'free',
-        comment: 'Defines access control scope: course | module | lesson'
-    })
-    accessScope: string;
+  @Column({
+    name: 'access_scope',
+    type: 'varchar',
+    length: 20,
+    default: 'free',
+    comment: 'Defines access control scope: course | module | lesson',
+  })
+  accessScope: string;
 
-    @Column({ name: 'is_paid', default: false, comment: 'If true and accessScope=course, entire course is paywalled' })
-    isPaid: boolean;
+  @Column({
+    name: 'is_paid',
+    default: false,
+    comment: 'If true and accessScope=course, entire course is paywalled',
+  })
+  isPaid: boolean;
 
-    @Column({
-        name: 'preview_limit',
-        type: 'int',
-        nullable: true,
-        comment: 'How many lessons can be free previews (e.g., 3-4). Optional.'
-    })
-    previewLimit: number | null;
+  @Column({
+    name: 'preview_limit',
+    type: 'int',
+    nullable: true,
+    comment: 'How many lessons can be free previews (e.g., 3-4). Optional.',
+  })
+  previewLimit: number | null;
 
-    @Column({ name: 'price_in_cents', type: 'int', nullable: true })
-    priceInCents: number | null;
+  @Column({ name: 'price_in_cents', type: 'int', nullable: true })
+  priceInCents: number | null;
 
-    @Column({ name: 'price_label', type: 'varchar', nullable: true })
-    priceLabel: string | null;
+  @Column({ name: 'price_label', type: 'varchar', nullable: true })
+  priceLabel: string | null;
 
-    @Column({ name: 'learning_points', type: 'text', array: true, nullable: true })
-    learningPoints: string[] | null;
+  @Column({
+    name: 'learning_points',
+    type: 'text',
+    array: true,
+    nullable: true,
+  })
+  learningPoints: string[] | null;
 
-    @Column({ name: 'features', type: 'jsonb', nullable: true })
-    features: string[] | null;
+  @Column({ name: 'features', type: 'jsonb', nullable: true })
+  features: string[] | null;
 
-    @CreateDateColumn({ name: 'created_at' })
-    createdAt: Date;
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
 
-    @UpdateDateColumn({ name: 'updated_at' })
-    updatedAt: Date;
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
 }

--- a/content-ms/src/content/entities/lesson.entity.ts
+++ b/content-ms/src/content/entities/lesson.entity.ts
@@ -1,42 +1,59 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 import { Module } from './module.entity';
 
 @Entity('lessons')
 export class Lesson {
-    @PrimaryGeneratedColumn('uuid')
-    id: string;
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
 
-    @Column()
-    title: string;
+  @Column()
+  title: string;
 
-    @Column({ type: 'text', nullable: true })
-    content: string;
+  @Column({ type: 'text', nullable: true })
+  content: string;
 
-    @Column({ nullable: true })
-    videoUrl: string; // Cloudinary URL
+  @Column({ nullable: true })
+  videoUrl: string; // Cloudinary URL
 
-    @Column({ nullable: true })
-    durationSeconds: number;
+  @Column({ nullable: true })
+  durationSeconds: number;
 
-    @ManyToOne(() => Module, (module) => module.lessons, { onDelete: 'CASCADE' })
-    @JoinColumn({ name: 'module_id' })
-    module: Module;
+  @ManyToOne(() => Module, (module) => module.lessons, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'module_id' })
+  module: Module;
 
-    @Column({ name: 'module_id', type: 'uuid' })
-    moduleId: string;
+  @Column({ name: 'module_id', type: 'uuid' })
+  moduleId: string;
 
-    @Column({ default: 0 })
-    order: number;
+  @Column({ default: 0 })
+  order: number;
 
-@Column({ name: 'is_paid', default: false, comment: 'If true (and accessScope=lesson), user must pay to view video/content' })
-isPaid: boolean;
+  @Column({
+    name: 'is_paid',
+    default: false,
+    comment:
+      'If true (and accessScope=lesson), user must pay to view video/content',
+  })
+  isPaid: boolean;
 
-@Column({ name: 'is_free_preview', default: false, comment: 'If true, lesson remains free even when course is paid' })
-isFreePreview: boolean;
+  @Column({
+    name: 'is_free_preview',
+    default: false,
+    comment: 'If true, lesson remains free even when course is paid',
+  })
+  isFreePreview: boolean;
 
-    @CreateDateColumn({ name: 'created_at' })
-    createdAt: Date;
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
 
-    @UpdateDateColumn({ name: 'updated_at' })
-    updatedAt: Date;
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
 }

--- a/content-ms/src/content/entities/module.entity.ts
+++ b/content-ms/src/content/entities/module.entity.ts
@@ -1,37 +1,50 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany, JoinColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  OneToMany,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 import { Course } from './course.entity';
 import { Lesson } from './lesson.entity';
 
 @Entity('course_modules')
 export class Module {
-    @PrimaryGeneratedColumn('uuid')
-    id: string;
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
 
-    @Column()
-    title: string;
+  @Column()
+  title: string;
 
-    @Column({ nullable: true })
-    description: string;
+  @Column({ nullable: true })
+  description: string;
 
-    @ManyToOne(() => Course, (course) => course.modules, { onDelete: 'CASCADE' })
-    @JoinColumn({ name: 'course_id' })
-    course: Course;
+  @ManyToOne(() => Course, (course) => course.modules, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'course_id' })
+  course: Course;
 
-    @Column({ name: 'course_id', type: 'uuid' })
-    courseId: string;
+  @Column({ name: 'course_id', type: 'uuid' })
+  courseId: string;
 
-    @OneToMany(() => Lesson, (lesson) => lesson.module)
-    lessons: Lesson[];
+  @OneToMany(() => Lesson, (lesson) => lesson.module)
+  lessons: Lesson[];
 
-    @Column({ default: 0 })
-    order: number;
+  @Column({ default: 0 })
+  order: number;
 
-@Column({ name: 'is_paid', default: false, comment: 'Marks whole module as paid when course accessScope=module' })
-isPaid: boolean;
+  @Column({
+    name: 'is_paid',
+    default: false,
+    comment: 'Marks whole module as paid when course accessScope=module',
+  })
+  isPaid: boolean;
 
-    @CreateDateColumn({ name: 'created_at' })
-    createdAt: Date;
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
 
-    @UpdateDateColumn({ name: 'updated_at' })
-    updatedAt: Date;
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
 }

--- a/content-ms/src/content/entities/pricing-plan.entity.ts
+++ b/content-ms/src/content/entities/pricing-plan.entity.ts
@@ -1,56 +1,62 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 
 @Entity('pricing_plans')
 export class PricingPlan {
-    @PrimaryGeneratedColumn('uuid')
-    id: string;
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
 
-    @Column({ nullable: true })
-    name: string;
+  @Column({ nullable: true })
+  name: string;
 
-    @Column({ nullable: true })
-    type: string; // 'personal' | 'empresa'
+  @Column({ nullable: true })
+  type: string; // 'personal' | 'empresa'
 
-    @Column({ name: 'price_monthly', nullable: true })
-    price_monthly: string;
+  @Column({ name: 'price_monthly', nullable: true })
+  price_monthly: string;
 
-    @Column({ name: 'price_annual', nullable: true })
-    price_annual: string;
+  @Column({ name: 'price_annual', nullable: true })
+  price_annual: string;
 
-    @Column({ name: 'price_monthly_cents', type: 'bigint', nullable: true })
-    price_monthly_cents: number;
+  @Column({ name: 'price_monthly_cents', type: 'bigint', nullable: true })
+  price_monthly_cents: number;
 
-    @Column({ name: 'price_annual_cents', type: 'bigint', nullable: true })
-    price_annual_cents: number;
+  @Column({ name: 'price_annual_cents', type: 'bigint', nullable: true })
+  price_annual_cents: number;
 
-    @Column({ name: 'plan_type', nullable: true })
-    plan_type: string;
+  @Column({ name: 'plan_type', nullable: true })
+  plan_type: string;
 
-    @Column({ name: 'is_free', default: false })
-    is_free: boolean;
+  @Column({ name: 'is_free', default: false })
+  is_free: boolean;
 
-    @Column({ type: 'text', nullable: true })
-    description: string;
+  @Column({ type: 'text', nullable: true })
+  description: string;
 
-    @Column({ name: 'button_text', nullable: true })
-    button_text: string;
+  @Column({ name: 'button_text', nullable: true })
+  button_text: string;
 
-    @Column('jsonb', { default: [] })
-    includes: string[];
+  @Column('jsonb', { default: [] })
+  includes: string[];
 
-    @Column('jsonb', { default: [] })
-    excludes: string[];
+  @Column('jsonb', { default: [] })
+  excludes: string[];
 
-    @Column({ name: 'is_active', default: true })
-    is_active: boolean;
+  @Column({ name: 'is_active', default: true })
+  is_active: boolean;
 
-    // Billing interval in months: 1=monthly, 2=bimonthly, 3=quarterly, 6=semiannual, 12=annual
-    @Column({ name: 'billing_interval_months', type: 'int', default: 1 })
-    billing_interval_months: number;
+  // Billing interval in months: 1=monthly, 2=bimonthly, 3=quarterly, 6=semiannual, 12=annual
+  @Column({ name: 'billing_interval_months', type: 'int', default: 1 })
+  billing_interval_months: number;
 
-    @Column('jsonb', { nullable: true, default: {} })
-    features: any;
+  @Column('jsonb', { nullable: true, default: {} })
+  features: any;
 
-    @Column({ default: 0 })
-    order: number;
+  @Column({ default: 0 })
+  order: number;
 }

--- a/content-ms/src/content/pricing.controller.ts
+++ b/content-ms/src/content/pricing.controller.ts
@@ -5,32 +5,32 @@ import { PricingPlan } from './entities/pricing-plan.entity';
 
 @Controller()
 export class PricingController {
-    constructor(private readonly pricingService: PricingService) { }
+  constructor(private readonly pricingService: PricingService) {}
 
-    @MessagePattern('pricing.findAll')
-    async findAll(@Payload() activeOnly: boolean = true) {
-        // Init defaults if empty
-        await this.pricingService.seedDefaults();
-        return this.pricingService.findAll(activeOnly);
-    }
+  @MessagePattern('pricing.findAll')
+  async findAll(@Payload() activeOnly: boolean = true) {
+    // Init defaults if empty
+    await this.pricingService.seedDefaults();
+    return this.pricingService.findAll(activeOnly);
+  }
 
-    @MessagePattern('pricing.findOne')
-    async findOne(@Payload() id: string) {
-        return this.pricingService.findOne(id);
-    }
+  @MessagePattern('pricing.findOne')
+  async findOne(@Payload() id: string) {
+    return this.pricingService.findOne(id);
+  }
 
-    @MessagePattern('pricing.create')
-    async create(@Payload() data: Partial<PricingPlan>) {
-        return this.pricingService.create(data);
-    }
+  @MessagePattern('pricing.create')
+  async create(@Payload() data: Partial<PricingPlan>) {
+    return this.pricingService.create(data);
+  }
 
-    @MessagePattern('pricing.update')
-    async update(@Payload() payload: { id: string, data: Partial<PricingPlan> }) {
-        return this.pricingService.update(payload.id, payload.data);
-    }
+  @MessagePattern('pricing.update')
+  async update(@Payload() payload: { id: string; data: Partial<PricingPlan> }) {
+    return this.pricingService.update(payload.id, payload.data);
+  }
 
-    @MessagePattern('pricing.delete')
-    async delete(@Payload() id: string) {
-        return this.pricingService.delete(id);
-    }
+  @MessagePattern('pricing.delete')
+  async delete(@Payload() id: string) {
+    return this.pricingService.delete(id);
+  }
 }

--- a/content-ms/src/content/pricing.service.ts
+++ b/content-ms/src/content/pricing.service.ts
@@ -5,86 +5,99 @@ import { PricingPlan } from './entities/pricing-plan.entity';
 
 @Injectable()
 export class PricingService {
-    constructor(
-        @InjectRepository(PricingPlan)
-        private readonly pricingRepo: Repository<PricingPlan>,
-    ) { }
+  constructor(
+    @InjectRepository(PricingPlan)
+    private readonly pricingRepo: Repository<PricingPlan>,
+  ) {}
 
-    async findAll(activeOnly: boolean = true) {
-        const query = this.pricingRepo.createQueryBuilder('plan');
-        if (activeOnly) {
-            query.where('plan.is_active = :active', { active: true });
-        }
-        return query.orderBy('plan.order', 'ASC').getMany();
+  async findAll(activeOnly: boolean = true) {
+    const query = this.pricingRepo.createQueryBuilder('plan');
+    if (activeOnly) {
+      query.where('plan.is_active = :active', { active: true });
     }
+    return query.orderBy('plan.order', 'ASC').getMany();
+  }
 
-    async findOne(id: string) {
-        const plan = await this.pricingRepo.findOne({ where: { id } });
-        if (!plan) throw new NotFoundException('Plan not found');
-        return plan;
+  async findOne(id: string) {
+    const plan = await this.pricingRepo.findOne({ where: { id } });
+    if (!plan) throw new NotFoundException('Plan not found');
+    return plan;
+  }
+
+  async create(data: Partial<PricingPlan>) {
+    const plan = this.pricingRepo.create(data);
+    return this.pricingRepo.save(plan);
+  }
+
+  async update(id: string, data: Partial<PricingPlan>) {
+    const plan = await this.findOne(id);
+    Object.assign(plan, data);
+    return this.pricingRepo.save(plan);
+  }
+
+  async delete(id: string) {
+    const plan = await this.findOne(id);
+    await this.pricingRepo.remove(plan);
+    return { deleted: true, id };
+  }
+
+  async seedDefaults() {
+    const count = await this.pricingRepo.count();
+    if (count > 0) return;
+
+    const defaults = [
+      // Personal
+      {
+        name: 'Gratis',
+        type: 'personal',
+        price_monthly: 'Gratis',
+        price_annual: 'Gratis',
+        description: 'Perfecto para empezar a aprender señas básicas.',
+        button_text: 'Comenzar Gratis',
+        includes: [
+          'Acceso a lecciones básicas',
+          'Diccionario limitado',
+          'Comunidad básica',
+        ],
+        excludes: ['Certificados', 'Videos HD', 'Soporte prioritario'],
+        order: 1,
+      },
+      {
+        name: 'Premium',
+        type: 'personal',
+        price_monthly: 'COP 29.900',
+        price_annual: 'COP 299.000',
+        description: 'Para estudiantes dedicados que quieren dominar la LSC.',
+        button_text: 'Obtener Premium',
+        includes: [
+          'Todo lo de Gratis',
+          'Lecciones avanzadas',
+          'Sin publicidad',
+          'Certificados',
+        ],
+        excludes: [],
+        order: 2,
+      },
+      // Empresa
+      {
+        name: 'Negocios',
+        type: 'empresa',
+        price_monthly: 'COP 199.000',
+        price_annual: 'COP 1.990.000',
+        description: 'Para pequeñas empresas inclusivas.',
+        button_text: 'Contactar Ventas',
+        includes: [
+          'Hasta 10 usuarios',
+          'Dashboard de uso',
+          'Facturación centralizada',
+        ],
+        excludes: [],
+        order: 1,
+      },
+    ];
+
+    for (const p of defaults) {
+      await this.pricingRepo.save(this.pricingRepo.create(p as any));
     }
-
-    async create(data: Partial<PricingPlan>) {
-        const plan = this.pricingRepo.create(data);
-        return this.pricingRepo.save(plan);
-    }
-
-    async update(id: string, data: Partial<PricingPlan>) {
-        const plan = await this.findOne(id);
-        Object.assign(plan, data);
-        return this.pricingRepo.save(plan);
-    }
-
-    async delete(id: string) {
-        const plan = await this.findOne(id);
-        await this.pricingRepo.remove(plan);
-        return { deleted: true, id };
-    }
-
-    async seedDefaults() {
-        const count = await this.pricingRepo.count();
-        if (count > 0) return;
-
-        const defaults = [
-            // Personal
-            {
-                name: 'Gratis',
-                type: 'personal',
-                price_monthly: 'Gratis',
-                price_annual: 'Gratis',
-                description: 'Perfecto para empezar a aprender señas básicas.',
-                button_text: 'Comenzar Gratis',
-                includes: ['Acceso a lecciones básicas', 'Diccionario limitado', 'Comunidad básica'],
-                excludes: ['Certificados', 'Videos HD', 'Soporte prioritario'],
-                order: 1
-            },
-            {
-                name: 'Premium',
-                type: 'personal',
-                price_monthly: 'COP 29.900',
-                price_annual: 'COP 299.000',
-                description: 'Para estudiantes dedicados que quieren dominar la LSC.',
-                button_text: 'Obtener Premium',
-                includes: ['Todo lo de Gratis', 'Lecciones avanzadas', 'Sin publicidad', 'Certificados'],
-                excludes: [],
-                order: 2
-            },
-            // Empresa
-            {
-                name: 'Negocios',
-                type: 'empresa',
-                price_monthly: 'COP 199.000',
-                price_annual: 'COP 1.990.000',
-                description: 'Para pequeñas empresas inclusivas.',
-                button_text: 'Contactar Ventas',
-                includes: ['Hasta 10 usuarios', 'Dashboard de uso', 'Facturación centralizada'],
-                excludes: [],
-                order: 1
-            }
-        ];
-
-        for (const p of defaults) {
-            await this.pricingRepo.save(this.pricingRepo.create(p as any));
-        }
-    }
+  }
 }

--- a/content-ms/src/filters/rpc-exception.filter.ts
+++ b/content-ms/src/filters/rpc-exception.filter.ts
@@ -4,13 +4,16 @@ import { RpcException } from '@nestjs/microservices';
 
 @Catch()
 export class AllExceptionsFilter implements RpcExceptionFilter<any> {
-    catch(exception: any, host: ArgumentsHost): Observable<any> {
-        const error = exception?.response || exception?.message || exception;
+  catch(exception: any, host: ArgumentsHost): Observable<any> {
+    const error = exception?.response || exception?.message || exception;
 
-        return throwError(() => new RpcException({
-            statusCode: exception?.status || exception?.statusCode || 500,
-            message: error?.message || error || 'Internal server error',
-            error: error?.error || 'Error',
-        }));
-    }
+    return throwError(
+      () =>
+        new RpcException({
+          statusCode: exception?.status || exception?.statusCode || 500,
+          message: error?.message || error || 'Internal server error',
+          error: error?.error || 'Error',
+        }),
+    );
+  }
 }

--- a/content-ms/src/landing-config/dto/faq.dto.ts
+++ b/content-ms/src/landing-config/dto/faq.dto.ts
@@ -1,30 +1,30 @@
 import { IsString, IsNumber, IsOptional } from 'class-validator';
 
 export class CreateFaqDto {
-    @IsString()
-    question: string;
+  @IsString()
+  question: string;
 
-    @IsString()
-    answer: string;
+  @IsString()
+  answer: string;
 
-    @IsNumber()
-    @IsOptional()
-    order?: number;
+  @IsNumber()
+  @IsOptional()
+  order?: number;
 }
 
 export class UpdateFaqDto {
-    @IsString()
-    id: string;
+  @IsString()
+  id: string;
 
-    @IsString()
-    @IsOptional()
-    question?: string;
+  @IsString()
+  @IsOptional()
+  question?: string;
 
-    @IsString()
-    @IsOptional()
-    answer?: string;
+  @IsString()
+  @IsOptional()
+  answer?: string;
 
-    @IsNumber()
-    @IsOptional()
-    order?: number;
+  @IsNumber()
+  @IsOptional()
+  order?: number;
 }

--- a/content-ms/src/landing-config/dto/testimonial.dto.ts
+++ b/content-ms/src/landing-config/dto/testimonial.dto.ts
@@ -1,49 +1,49 @@
 import { IsString, IsNumber, IsOptional, Min, Max } from 'class-validator';
 
 export class CreateTestimonialDto {
-    @IsString()
-    authorName: string;
+  @IsString()
+  authorName: string;
 
-    @IsString()
-    authorRole: string;
+  @IsString()
+  authorRole: string;
 
-    @IsString()
-    quote: string;
+  @IsString()
+  quote: string;
 
-    @IsNumber()
-    @Min(1)
-    @Max(5)
-    @IsOptional()
-    rating?: number;
+  @IsNumber()
+  @Min(1)
+  @Max(5)
+  @IsOptional()
+  rating?: number;
 
-    @IsNumber()
-    @IsOptional()
-    order?: number;
+  @IsNumber()
+  @IsOptional()
+  order?: number;
 }
 
 export class UpdateTestimonialDto {
-    @IsString()
-    id: string;
+  @IsString()
+  id: string;
 
-    @IsString()
-    @IsOptional()
-    authorName?: string;
+  @IsString()
+  @IsOptional()
+  authorName?: string;
 
-    @IsString()
-    @IsOptional()
-    authorRole?: string;
+  @IsString()
+  @IsOptional()
+  authorRole?: string;
 
-    @IsString()
-    @IsOptional()
-    quote?: string;
+  @IsString()
+  @IsOptional()
+  quote?: string;
 
-    @IsNumber()
-    @Min(1)
-    @Max(5)
-    @IsOptional()
-    rating?: number;
+  @IsNumber()
+  @Min(1)
+  @Max(5)
+  @IsOptional()
+  rating?: number;
 
-    @IsNumber()
-    @IsOptional()
-    order?: number;
+  @IsNumber()
+  @IsOptional()
+  order?: number;
 }

--- a/content-ms/src/landing-config/dto/update-landing-config.dto.ts
+++ b/content-ms/src/landing-config/dto/update-landing-config.dto.ts
@@ -1,15 +1,15 @@
 import { IsString, IsNotEmpty, IsOptional } from 'class-validator';
 
 export class UpdateLandingConfigDto {
-    @IsString()
-    @IsNotEmpty()
-    key: string;
+  @IsString()
+  @IsNotEmpty()
+  key: string;
 
-    @IsString()
-    @IsNotEmpty()
-    value: string;
+  @IsString()
+  @IsNotEmpty()
+  value: string;
 
-    @IsString()
-    @IsOptional()
-    description?: string;
+  @IsString()
+  @IsOptional()
+  description?: string;
 }

--- a/content-ms/src/landing-config/entities/faq.entity.ts
+++ b/content-ms/src/landing-config/entities/faq.entity.ts
@@ -1,22 +1,28 @@
-import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 
 @Entity('faqs')
 export class FAQ {
-    @PrimaryGeneratedColumn('uuid')
-    id: string;
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
 
-    @Column()
-    question: string;
+  @Column()
+  question: string;
 
-    @Column('text')
-    answer: string;
+  @Column('text')
+  answer: string;
 
-    @Column({ default: 0 })
-    order: number;
+  @Column({ default: 0 })
+  order: number;
 
-    @CreateDateColumn({ name: 'created_at' })
-    createdAt: Date;
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
 
-    @UpdateDateColumn({ name: 'updated_at' })
-    updatedAt: Date;
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
 }

--- a/content-ms/src/landing-config/entities/landing-config.entity.ts
+++ b/content-ms/src/landing-config/entities/landing-config.entity.ts
@@ -2,15 +2,15 @@ import { Entity, Column, PrimaryColumn, UpdateDateColumn } from 'typeorm';
 
 @Entity('landing_page_config')
 export class LandingPageConfig {
-    @PrimaryColumn()
-    key: string;
+  @PrimaryColumn()
+  key: string;
 
-    @Column()
-    value: string;
+  @Column()
+  value: string;
 
-    @Column({ nullable: true })
-    description: string;
+  @Column({ nullable: true })
+  description: string;
 
-    @UpdateDateColumn({ name: 'updated_at' })
-    updatedAt: Date;
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
 }

--- a/content-ms/src/landing-config/entities/testimonial.entity.ts
+++ b/content-ms/src/landing-config/entities/testimonial.entity.ts
@@ -1,28 +1,34 @@
-import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 
 @Entity('testimonials')
 export class Testimonial {
-    @PrimaryGeneratedColumn('uuid')
-    id: string;
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
 
-    @Column({ name: 'author_name' })
-    authorName: string;
+  @Column({ name: 'author_name' })
+  authorName: string;
 
-    @Column({ name: 'author_role' })
-    authorRole: string;
+  @Column({ name: 'author_role' })
+  authorRole: string;
 
-    @Column('text')
-    quote: string;
+  @Column('text')
+  quote: string;
 
-    @Column({ default: 5 })
-    rating: number;
+  @Column({ default: 5 })
+  rating: number;
 
-    @Column({ default: 0 })
-    order: number;
+  @Column({ default: 0 })
+  order: number;
 
-    @CreateDateColumn({ name: 'created_at' })
-    createdAt: Date;
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
 
-    @UpdateDateColumn({ name: 'updated_at' })
-    updatedAt: Date;
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
 }

--- a/content-ms/src/landing-config/landing-config.controller.ts
+++ b/content-ms/src/landing-config/landing-config.controller.ts
@@ -2,83 +2,86 @@ import { Controller } from '@nestjs/common';
 import { MessagePattern, Payload } from '@nestjs/microservices';
 import { LandingConfigService } from './landing-config.service';
 import { UpdateLandingConfigDto } from './dto/update-landing-config.dto';
-import { CreateTestimonialDto, UpdateTestimonialDto } from './dto/testimonial.dto';
+import {
+  CreateTestimonialDto,
+  UpdateTestimonialDto,
+} from './dto/testimonial.dto';
 import { CreateFaqDto, UpdateFaqDto } from './dto/faq.dto';
 
 @Controller()
 export class LandingConfigController {
-    constructor(private readonly landingConfigService: LandingConfigService) { }
+  constructor(private readonly landingConfigService: LandingConfigService) {}
 
-    // ============ Landing Config Endpoints ============
-    @MessagePattern('get_landing_config')
-    findAll() {
-        return this.landingConfigService.findAll();
-    }
+  // ============ Landing Config Endpoints ============
+  @MessagePattern('get_landing_config')
+  findAll() {
+    return this.landingConfigService.findAll();
+  }
 
-    @MessagePattern('get_landing_config_by_key')
-    findOne(@Payload() data: { key: string }) {
-        return this.landingConfigService.findOne(data.key);
-    }
+  @MessagePattern('get_landing_config_by_key')
+  findOne(@Payload() data: { key: string }) {
+    return this.landingConfigService.findOne(data.key);
+  }
 
-    @MessagePattern('update_landing_config')
-    update(@Payload() updateLandingConfigDto: UpdateLandingConfigDto) {
-        return this.landingConfigService.update(updateLandingConfigDto);
-    }
+  @MessagePattern('update_landing_config')
+  update(@Payload() updateLandingConfigDto: UpdateLandingConfigDto) {
+    return this.landingConfigService.update(updateLandingConfigDto);
+  }
 
-    @MessagePattern('delete_landing_config')
-    delete(@Payload() data: { key: string }) {
-        return this.landingConfigService.delete(data.key);
-    }
+  @MessagePattern('delete_landing_config')
+  delete(@Payload() data: { key: string }) {
+    return this.landingConfigService.delete(data.key);
+  }
 
-    // ============ Testimonial Endpoints ============
-    @MessagePattern('get_testimonials')
-    findAllTestimonials() {
-        return this.landingConfigService.findAllTestimonials();
-    }
+  // ============ Testimonial Endpoints ============
+  @MessagePattern('get_testimonials')
+  findAllTestimonials() {
+    return this.landingConfigService.findAllTestimonials();
+  }
 
-    @MessagePattern('get_testimonial')
-    findOneTestimonial(@Payload() data: { id: string }) {
-        return this.landingConfigService.findOneTestimonial(data.id);
-    }
+  @MessagePattern('get_testimonial')
+  findOneTestimonial(@Payload() data: { id: string }) {
+    return this.landingConfigService.findOneTestimonial(data.id);
+  }
 
-    @MessagePattern('create_testimonial')
-    createTestimonial(@Payload() createTestimonialDto: CreateTestimonialDto) {
-        return this.landingConfigService.createTestimonial(createTestimonialDto);
-    }
+  @MessagePattern('create_testimonial')
+  createTestimonial(@Payload() createTestimonialDto: CreateTestimonialDto) {
+    return this.landingConfigService.createTestimonial(createTestimonialDto);
+  }
 
-    @MessagePattern('update_testimonial')
-    updateTestimonial(@Payload() updateTestimonialDto: UpdateTestimonialDto) {
-        return this.landingConfigService.updateTestimonial(updateTestimonialDto);
-    }
+  @MessagePattern('update_testimonial')
+  updateTestimonial(@Payload() updateTestimonialDto: UpdateTestimonialDto) {
+    return this.landingConfigService.updateTestimonial(updateTestimonialDto);
+  }
 
-    @MessagePattern('delete_testimonial')
-    deleteTestimonial(@Payload() data: { id: string }) {
-        return this.landingConfigService.deleteTestimonial(data.id);
-    }
+  @MessagePattern('delete_testimonial')
+  deleteTestimonial(@Payload() data: { id: string }) {
+    return this.landingConfigService.deleteTestimonial(data.id);
+  }
 
-    // ============ FAQ Endpoints ============
-    @MessagePattern('get_faqs')
-    findAllFaqs() {
-        return this.landingConfigService.findAllFaqs();
-    }
+  // ============ FAQ Endpoints ============
+  @MessagePattern('get_faqs')
+  findAllFaqs() {
+    return this.landingConfigService.findAllFaqs();
+  }
 
-    @MessagePattern('get_faq')
-    findOneFaq(@Payload() data: { id: string }) {
-        return this.landingConfigService.findOneFaq(data.id);
-    }
+  @MessagePattern('get_faq')
+  findOneFaq(@Payload() data: { id: string }) {
+    return this.landingConfigService.findOneFaq(data.id);
+  }
 
-    @MessagePattern('create_faq')
-    createFaq(@Payload() createFaqDto: CreateFaqDto) {
-        return this.landingConfigService.createFaq(createFaqDto);
-    }
+  @MessagePattern('create_faq')
+  createFaq(@Payload() createFaqDto: CreateFaqDto) {
+    return this.landingConfigService.createFaq(createFaqDto);
+  }
 
-    @MessagePattern('update_faq')
-    updateFaq(@Payload() updateFaqDto: UpdateFaqDto) {
-        return this.landingConfigService.updateFaq(updateFaqDto);
-    }
+  @MessagePattern('update_faq')
+  updateFaq(@Payload() updateFaqDto: UpdateFaqDto) {
+    return this.landingConfigService.updateFaq(updateFaqDto);
+  }
 
-    @MessagePattern('delete_faq')
-    deleteFaq(@Payload() data: { id: string }) {
-        return this.landingConfigService.deleteFaq(data.id);
-    }
+  @MessagePattern('delete_faq')
+  deleteFaq(@Payload() data: { id: string }) {
+    return this.landingConfigService.deleteFaq(data.id);
+  }
 }

--- a/content-ms/src/landing-config/landing-config.module.ts
+++ b/content-ms/src/landing-config/landing-config.module.ts
@@ -7,9 +7,8 @@ import { Testimonial } from './entities/testimonial.entity';
 import { FAQ } from './entities/faq.entity';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([LandingPageConfig, Testimonial, FAQ])],
-    controllers: [LandingConfigController],
-    providers: [LandingConfigService],
+  imports: [TypeOrmModule.forFeature([LandingPageConfig, Testimonial, FAQ])],
+  controllers: [LandingConfigController],
+  providers: [LandingConfigService],
 })
-export class LandingConfigModule { }
-
+export class LandingConfigModule {}

--- a/content-ms/src/landing-config/landing-config.service.ts
+++ b/content-ms/src/landing-config/landing-config.service.ts
@@ -5,126 +5,135 @@ import { LandingPageConfig } from './entities/landing-config.entity';
 import { Testimonial } from './entities/testimonial.entity';
 import { FAQ } from './entities/faq.entity';
 import { UpdateLandingConfigDto } from './dto/update-landing-config.dto';
-import { CreateTestimonialDto, UpdateTestimonialDto } from './dto/testimonial.dto';
+import {
+  CreateTestimonialDto,
+  UpdateTestimonialDto,
+} from './dto/testimonial.dto';
 import { CreateFaqDto, UpdateFaqDto } from './dto/faq.dto';
 
 @Injectable()
 export class LandingConfigService {
-    constructor(
-        @InjectRepository(LandingPageConfig)
-        private readonly landingConfigRepository: Repository<LandingPageConfig>,
-        @InjectRepository(Testimonial)
-        private readonly testimonialRepository: Repository<Testimonial>,
-        @InjectRepository(FAQ)
-        private readonly faqRepository: Repository<FAQ>,
-    ) { }
+  constructor(
+    @InjectRepository(LandingPageConfig)
+    private readonly landingConfigRepository: Repository<LandingPageConfig>,
+    @InjectRepository(Testimonial)
+    private readonly testimonialRepository: Repository<Testimonial>,
+    @InjectRepository(FAQ)
+    private readonly faqRepository: Repository<FAQ>,
+  ) {}
 
-    // ============ Landing Config Methods ============
-    async findAll() {
-        return this.landingConfigRepository.find({
-            order: { key: 'ASC' }
-        });
+  // ============ Landing Config Methods ============
+  async findAll() {
+    return this.landingConfigRepository.find({
+      order: { key: 'ASC' },
+    });
+  }
+
+  async findOne(key: string) {
+    const config = await this.landingConfigRepository.findOne({
+      where: { key },
+    });
+    if (!config) {
+      return null; // Return null instead of throwing for optional configs
+    }
+    return config;
+  }
+
+  async update(updateLandingConfigDto: UpdateLandingConfigDto) {
+    const { key, value, description } = updateLandingConfigDto;
+
+    let config = await this.landingConfigRepository.findOne({ where: { key } });
+
+    if (config) {
+      config.value = value;
+      if (description) config.description = description;
+    } else {
+      config = this.landingConfigRepository.create({
+        key,
+        value,
+        description,
+      });
     }
 
-    async findOne(key: string) {
-        const config = await this.landingConfigRepository.findOne({ where: { key } });
-        if (!config) {
-            return null; // Return null instead of throwing for optional configs
-        }
-        return config;
+    return this.landingConfigRepository.save(config);
+  }
+
+  async delete(key: string) {
+    const config = await this.landingConfigRepository.findOne({
+      where: { key },
+    });
+    if (!config) {
+      throw new NotFoundException(`Config with key ${key} not found`);
     }
+    await this.landingConfigRepository.remove(config);
+    return { deleted: true, key };
+  }
 
-    async update(updateLandingConfigDto: UpdateLandingConfigDto) {
-        const { key, value, description } = updateLandingConfigDto;
+  // ============ Testimonial Methods ============
+  async findAllTestimonials() {
+    return this.testimonialRepository.find({
+      order: { order: 'ASC' },
+    });
+  }
 
-        let config = await this.landingConfigRepository.findOne({ where: { key } });
-
-        if (config) {
-            config.value = value;
-            if (description) config.description = description;
-        } else {
-            config = this.landingConfigRepository.create({
-                key,
-                value,
-                description
-            });
-        }
-
-        return this.landingConfigRepository.save(config);
+  async findOneTestimonial(id: string) {
+    const testimonial = await this.testimonialRepository.findOne({
+      where: { id },
+    });
+    if (!testimonial) {
+      throw new NotFoundException(`Testimonial with id ${id} not found`);
     }
+    return testimonial;
+  }
 
-    async delete(key: string) {
-        const config = await this.landingConfigRepository.findOne({ where: { key } });
-        if (!config) {
-            throw new NotFoundException(`Config with key ${key} not found`);
-        }
-        await this.landingConfigRepository.remove(config);
-        return { deleted: true, key };
-    }
+  async createTestimonial(createTestimonialDto: CreateTestimonialDto) {
+    const testimonial = this.testimonialRepository.create(createTestimonialDto);
+    return this.testimonialRepository.save(testimonial);
+  }
 
-    // ============ Testimonial Methods ============
-    async findAllTestimonials() {
-        return this.testimonialRepository.find({
-            order: { order: 'ASC' }
-        });
-    }
+  async updateTestimonial(updateTestimonialDto: UpdateTestimonialDto) {
+    const { id, ...updateData } = updateTestimonialDto;
+    const testimonial = await this.findOneTestimonial(id);
+    Object.assign(testimonial, updateData);
+    return this.testimonialRepository.save(testimonial);
+  }
 
-    async findOneTestimonial(id: string) {
-        const testimonial = await this.testimonialRepository.findOne({ where: { id } });
-        if (!testimonial) {
-            throw new NotFoundException(`Testimonial with id ${id} not found`);
-        }
-        return testimonial;
-    }
+  async deleteTestimonial(id: string) {
+    const testimonial = await this.findOneTestimonial(id);
+    await this.testimonialRepository.remove(testimonial);
+    return { deleted: true, id };
+  }
 
-    async createTestimonial(createTestimonialDto: CreateTestimonialDto) {
-        const testimonial = this.testimonialRepository.create(createTestimonialDto);
-        return this.testimonialRepository.save(testimonial);
-    }
+  // ============ FAQ Methods ============
+  async findAllFaqs() {
+    return this.faqRepository.find({
+      order: { order: 'ASC' },
+    });
+  }
 
-    async updateTestimonial(updateTestimonialDto: UpdateTestimonialDto) {
-        const { id, ...updateData } = updateTestimonialDto;
-        const testimonial = await this.findOneTestimonial(id);
-        Object.assign(testimonial, updateData);
-        return this.testimonialRepository.save(testimonial);
+  async findOneFaq(id: string) {
+    const faq = await this.faqRepository.findOne({ where: { id } });
+    if (!faq) {
+      throw new NotFoundException(`FAQ with id ${id} not found`);
     }
+    return faq;
+  }
 
-    async deleteTestimonial(id: string) {
-        const testimonial = await this.findOneTestimonial(id);
-        await this.testimonialRepository.remove(testimonial);
-        return { deleted: true, id };
-    }
+  async createFaq(createFaqDto: CreateFaqDto) {
+    const faq = this.faqRepository.create(createFaqDto);
+    return this.faqRepository.save(faq);
+  }
 
-    // ============ FAQ Methods ============
-    async findAllFaqs() {
-        return this.faqRepository.find({
-            order: { order: 'ASC' }
-        });
-    }
+  async updateFaq(updateFaqDto: UpdateFaqDto) {
+    const { id, ...updateData } = updateFaqDto;
+    const faq = await this.findOneFaq(id);
+    Object.assign(faq, updateData);
+    return this.faqRepository.save(faq);
+  }
 
-    async findOneFaq(id: string) {
-        const faq = await this.faqRepository.findOne({ where: { id } });
-        if (!faq) {
-            throw new NotFoundException(`FAQ with id ${id} not found`);
-        }
-        return faq;
-    }
-
-    async createFaq(createFaqDto: CreateFaqDto) {
-        const faq = this.faqRepository.create(createFaqDto);
-        return this.faqRepository.save(faq);
-    }
-
-    async updateFaq(updateFaqDto: UpdateFaqDto) {
-        const { id, ...updateData } = updateFaqDto;
-        const faq = await this.findOneFaq(id);
-        Object.assign(faq, updateData);
-        return this.faqRepository.save(faq);
-    }
-
-    async deleteFaq(id: string) {
-        const faq = await this.findOneFaq(id);
-        await this.faqRepository.remove(faq);
-        return { deleted: true, id };
-    }
+  async deleteFaq(id: string) {
+    const faq = await this.findOneFaq(id);
+    await this.faqRepository.remove(faq);
+    return { deleted: true, id };
+  }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,110 @@
+version: '3.8'
+
+services:
+  api-gateway:
+    build:
+      context: ./api-gateway
+    container_name: api-gateway
+    ports:
+      - "3001:3001"
+    environment:
+      - PORT=3001
+      - authHost=auth-ms
+      - authPort=3002
+      - paymentsHost=payments-ms
+      - paymentsPort=3003
+      - formsHost=forms-ms
+      - formsPort=3004
+      - communicationHost=communication-ms
+      - communicationPort=3005
+      - chatHost=chat-ms
+      - chatPort=3006
+      - contactsHost=contacts-ms
+      - contactsPort=3007
+      - contentHost=content-ms
+      - contentPort=3008
+      - emergencyHost=emergency-ms
+      - emergencyPort=3009
+    env_file:
+      - ./api-gateway/.env
+    depends_on:
+      - auth-ms
+      - payments-ms
+      - forms-ms
+      - communication-ms
+      - chat-ms
+      - contacts-ms
+      - content-ms
+      - emergency-ms
+
+  auth-ms:
+    build:
+      context: ./auth-ms
+    container_name: auth-ms
+    environment:
+      - authPort=3002
+    env_file:
+      - ./auth-ms/.env
+
+  payments-ms:
+    build:
+      context: ./payments-ms
+    container_name: payments-ms
+    environment:
+      - paymentsPort=3003
+    env_file:
+      - ./payments-ms/.env
+
+  forms-ms:
+    build:
+      context: ./forms-ms
+    container_name: forms-ms
+    environment:
+      - formsPort=3004
+    env_file:
+      - ./forms-ms/.env
+
+  communication-ms:
+    build:
+      context: ./communication-ms
+    container_name: communication-ms
+    environment:
+      - communicationPort=3005
+    env_file:
+      - ./communication-ms/.env
+
+  chat-ms:
+    build:
+      context: ./chat-ms
+    container_name: chat-ms
+    environment:
+      - chatPort=3006
+    env_file:
+      - ./chat-ms/.env
+
+  contacts-ms:
+    build:
+      context: ./contacts-ms
+    container_name: contacts-ms
+    environment:
+      - contactsPort=3007
+    env_file:
+      - ./contacts-ms/.env
+
+  content-ms:
+    build:
+      context: ./content-ms
+    container_name: content-ms
+    environment:
+      - contentPort=3008
+    env_file:
+      - ./content-ms/.env
+
+  emergency-ms:
+    build:
+      context: ./emergency-ms
+    container_name: emergency-ms
+    environment:
+      - emergencyPort=3009
+    env_file:
+      - ./emergency-ms/.env

--- a/emergency-ms/.dockerignore
+++ b/emergency-ms/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.git
+.env

--- a/emergency-ms/Dockerfile
+++ b/emergency-ms/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:22-alpine
+WORKDIR /app
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/package.json ./
+CMD ["npm", "run", "start:prod"]

--- a/forms-ms/.dockerignore
+++ b/forms-ms/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.git
+.env

--- a/forms-ms/Dockerfile
+++ b/forms-ms/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:22-alpine
+WORKDIR /app
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/package.json ./
+CMD ["npm", "run", "start:prod"]

--- a/payments-ms/.dockerignore
+++ b/payments-ms/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.git
+.env

--- a/payments-ms/Dockerfile
+++ b/payments-ms/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:22-alpine
+WORKDIR /app
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/package.json ./
+CMD ["npm", "run", "start:prod"]


### PR DESCRIPTION
- Integración de `apn` (Apple Push Notification provider) para el envío de notificaciones VoIP silenciosas (`sendVoipPushNotification`) hacia el sufijo `.voip` en dispositivos iOS. Requisito indispensable para despertar la app en background vía CallKit.
- Inicialización de `firebase-admin` para orquestar notificaciones de solo datos (`sendFcmDataNotification`) en Android. Se forzó el nivel `priority: 'high'` para garantizar la intercepción en segundo plano y gatillar las UI de llamada entrante a través de CallKeep/ConnectionService.
- Reestructuración del `NotificationsService` para levantar dinámicamente los proveedores de APNs y FCM en el constructor usando variables de entorno (`APN_KEY`, `GOOGLE_APPLICATION_CREDENTIALS`).
- Implementación de un mecanismo de "simulación segura": si las variables de entorno no existen (ej. entornos de desarrollo locales), el servicio hace log en formato *warning* en lugar de crashear el módulo.
- Sanitización del payload en FCM para forzar mapeos de tipo `String` obligatorios en Firebase Data Messages (ej. `isGroup`, booleanos y números).